### PR TITLE
Added utility to convert secret and userId into session secret token

### DIFF
--- a/src/PinguApps.Appwrite.Shared/Utils/TokenUtils.cs
+++ b/src/PinguApps.Appwrite.Shared/Utils/TokenUtils.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace PinguApps.Appwrite.Shared.Utils;
+public static class TokenUtils
+{
+    private record SessionToken(
+        [property: JsonPropertyName("id")] string Id,
+        [property: JsonPropertyName("secret")] string Secret
+    );
+
+    public static string GetSessionToken(string userId, string secret)
+    {
+        var session = new SessionToken(userId, secret);
+
+        var jsonBytes = JsonSerializer.SerializeToUtf8Bytes(session);
+
+        return Convert.ToBase64String(jsonBytes);
+    }
+}

--- a/src/PinguApps.Appwrite.Shared/Utils/TokenUtils.cs
+++ b/src/PinguApps.Appwrite.Shared/Utils/TokenUtils.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 namespace PinguApps.Appwrite.Shared.Utils;
 public static class TokenUtils
 {
-    private record SessionToken(
+    internal record SessionToken(
         [property: JsonPropertyName("id")] string Id,
         [property: JsonPropertyName("secret")] string Secret
     );

--- a/tests/PinguApps.Appwrite.Shared.Tests/Utils/TokenUtilsTests.cs
+++ b/tests/PinguApps.Appwrite.Shared.Tests/Utils/TokenUtilsTests.cs
@@ -1,0 +1,25 @@
+﻿using System.Text.Json;
+using PinguApps.Appwrite.Shared.Utils;
+
+namespace PinguApps.Appwrite.Shared.Tests.Utils;
+public class TokenUtilsTests
+{
+    [Fact]
+    public void GetSessionToken_ShouldReturnBase64EncodedString()
+    {
+        // Arrange
+        string userId = "testUser";
+        string secret = "testSecret";
+
+        // Act
+        string result = TokenUtils.GetSessionToken(userId, secret);
+
+        // Assert
+        Assert.NotNull(result);
+        var jsonBytes = Convert.FromBase64String(result);
+        var session = JsonSerializer.Deserialize<TokenUtils.SessionToken>(jsonBytes);
+        Assert.NotNull(session);
+        Assert.Equal(userId, session.Id);
+        Assert.Equal(secret, session.Secret);
+    }
+}


### PR DESCRIPTION
# Changes
- Added utility to convert secret and userId into session secret token

## Issue
#135 

## Checklist before requesting a review
> The PR will only be considered when all items within the checklist are marked as complete. Feel free to submit an incomplete draft PR, and add additional commits until you are able to satisfy each item within the checklist.
- [x] I have performed a self-review of my code
- [x] I have submitted at most one additional endpoint implementation
- [x] I have either submitted no additional endpoint implementation, or my implementation covers both client and server SDK's, unless either are marked in the [README](https://github.com/PinguApps/AppwriteSdk/blob/dev/README.md) with a ❌
- [x] I have added applicable tests for my code
- [x] I have updated the [README](https://github.com/PinguApps/AppwriteSdk/blob/dev/README.md) with updated status as a result of this PR
