### PR TITLE
Refactor App class to change team operations from creation to retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,11 +141,11 @@ string emailAddressOrErrorMessage = userResponse.Result.Match(
 
 ## ⌛ Progress
 <!-- `red` for first third, `gold` for second third, `forestgreen` for final third, `blue` for 100% -->
-![Server & Client - 104 / 318](https://img.shields.io/badge/Server_&_Client-104%20%2F%20318-red?style=for-the-badge)
+![Server & Client - 106 / 318](https://img.shields.io/badge/Server_&_Client-106%20%2F%20318-gold?style=for-the-badge)
 
-![Server - 55 / 225](https://img.shields.io/badge/Server-55%20%2F%20225-red?style=for-the-badge)
+![Server - 56 / 225](https://img.shields.io/badge/Server-56%20%2F%20225-red?style=for-the-badge)
 
-![Client - 49 / 93](https://img.shields.io/badge/Client-49%20%2F%2093-gold?style=for-the-badge)
+![Client - 50 / 93](https://img.shields.io/badge/Client-50%20%2F%2093-gold?style=for-the-badge)
 
 ### 🔑 Key
 | Icon | Definition |
@@ -256,13 +256,13 @@ string emailAddressOrErrorMessage = userResponse.Result.Match(
 | [Update Phone Verification](https://appwrite.io/docs/references/1.6.x/server-rest/users#updatePhoneVerification) | ❌ | ✅ |
 
 ### Teams
-![Teams - 4 / 26](https://img.shields.io/badge/Teams-4%20%2F%2026-red?style=for-the-badge)
+![Teams - 6 / 26](https://img.shields.io/badge/Teams-6%20%2F%2026-red?style=for-the-badge)
 
 | Endpoint | Client | Server |
 |:-:|:-:|:-:|
 | [List Teams](https://appwrite.io/docs/references/1.6.x/client-rest/teams#list) | ✅ | ✅ |
 | [Create Team](https://appwrite.io/docs/references/1.6.x/client-rest/teams#create) | ✅ | ✅ |
-| [Get Team](https://appwrite.io/docs/references/1.6.x/client-rest/teams#get) | ⬛ | ⬛ |
+| [Get Team](https://appwrite.io/docs/references/1.6.x/client-rest/teams#get) | ✅ | ✅ |
 | [Update Name](https://appwrite.io/docs/references/1.6.x/client-rest/teams#updateName) | ⬛ | ⬛ |
 | [Delete Team](https://appwrite.io/docs/references/1.6.x/client-rest/teams#delete) | ⬛ | ⬛ |
 | [List Team Memberships](https://appwrite.io/docs/references/1.6.x/client-rest/teams#listMemberships) | ⬛ | ⬛ |

--- a/src/PinguApps.Appwrite.Client/Clients/ITeamsClient.cs
+++ b/src/PinguApps.Appwrite.Client/Clients/ITeamsClient.cs
@@ -30,7 +30,13 @@ public interface ITeamsClient
     Task<AppwriteResult<Team>> CreateTeam(CreateTeamRequest request);
     [Obsolete("This method hasn't yet been implemented!")]
     Task<AppwriteResult> DeleteTeam(DeleteTeamRequest request);
-    [Obsolete("This method hasn't yet been implemented!")]
+
+    /// <summary>
+    /// Get a team by its ID. All team members have read access for this resource.
+    /// <para><see href="https://appwrite.io/docs/references/1.6.x/client-rest/teams#get">Appwrite Docs</see></para>
+    /// </summary>
+    /// <param name="request">The request content</param>
+    /// <returns>The team</returns>
     Task<AppwriteResult<Team>> GetTeam(GetTeamRequest request);
     [Obsolete("This method hasn't yet been implemented!")]
     Task<AppwriteResult<Team>> UpdateName(UpdateNameRequest request);

--- a/src/PinguApps.Appwrite.Client/Clients/TeamsClient.cs
+++ b/src/PinguApps.Appwrite.Client/Clients/TeamsClient.cs
@@ -61,9 +61,22 @@ public class TeamsClient : SessionAwareClientBase, ITeamsClient
     /// <inheritdoc/>
     public Task<AppwriteResult> DeleteTeam(DeleteTeamRequest request) => throw new NotImplementedException();
 
-    [ExcludeFromCodeCoverage]
     /// <inheritdoc/>
-    public Task<AppwriteResult<Team>> GetTeam(GetTeamRequest request) => throw new NotImplementedException();
+    public async Task<AppwriteResult<Team>> GetTeam(GetTeamRequest request)
+    {
+        try
+        {
+            request.Validate(true);
+
+            var result = await _teamsApi.GetTeam(GetCurrentSessionOrThrow(), request.TeamId);
+
+            return result.GetApiResponse();
+        }
+        catch (Exception e)
+        {
+            return e.GetExceptionResponse<Team>();
+        }
+    }
 
     [ExcludeFromCodeCoverage]
     /// <inheritdoc/>

--- a/src/PinguApps.Appwrite.Playground/App.cs
+++ b/src/PinguApps.Appwrite.Playground/App.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Extensions.Configuration;
 using PinguApps.Appwrite.Shared.Requests.Teams;
-using PinguApps.Appwrite.Shared.Utils;
 
 namespace PinguApps.Appwrite.Playground;
 internal class App
@@ -20,13 +19,12 @@ internal class App
     {
         _client.SetSession(_session);
 
-        var request = new CreateTeamRequest()
+        var request = new GetTeamRequest()
         {
-            Name = "Client Team",
-            Roles = ["clients"]
+            TeamId = "6712ee0a003799f2c2ed"
         };
 
-        var clientResponse = await _client.Teams.CreateTeam(request);
+        var clientResponse = await _client.Teams.GetTeam(request);
 
         Console.WriteLine(clientResponse.Result.Match(
             result => result.ToString(),
@@ -35,11 +33,7 @@ internal class App
 
         Console.WriteLine("############################################################################");
 
-        request.TeamId = IdUtils.GenerateUniqueId();
-        request.Name = "Server Team";
-        request.Roles = [];
-
-        var serverResponse = await _server.Teams.CreateTeam(request);
+        var serverResponse = await _server.Teams.GetTeam(request);
 
         Console.WriteLine(serverResponse.Result.Match(
             result => result.ToString(),

--- a/src/PinguApps.Appwrite.Server/Clients/ITeamsClient.cs
+++ b/src/PinguApps.Appwrite.Server/Clients/ITeamsClient.cs
@@ -30,7 +30,13 @@ public interface ITeamsClient
     Task<AppwriteResult<Team>> CreateTeam(CreateTeamRequest request);
     [Obsolete("This method hasn't yet been implemented!")]
     Task<AppwriteResult> DeleteTeam(DeleteTeamRequest request);
-    [Obsolete("This method hasn't yet been implemented!")]
+
+    /// <summary>
+    /// Get a team by its ID. All team members have read access for this resource.
+    /// <para><see href="https://appwrite.io/docs/references/1.6.x/server-rest/teams#get">Appwrite Docs</see></para>
+    /// </summary>
+    /// <param name="request">The request content</param>
+    /// <returns>The team</returns>
     Task<AppwriteResult<Team>> GetTeam(GetTeamRequest request);
     [Obsolete("This method hasn't yet been implemented!")]
     Task<AppwriteResult<Team>> UpdateName(UpdateNameRequest request);

--- a/src/PinguApps.Appwrite.Server/Clients/TeamsClient.cs
+++ b/src/PinguApps.Appwrite.Server/Clients/TeamsClient.cs
@@ -61,9 +61,22 @@ public class TeamsClient : ITeamsClient
     /// <inheritdoc/>
     public Task<AppwriteResult> DeleteTeam(DeleteTeamRequest request) => throw new NotImplementedException();
 
-    [ExcludeFromCodeCoverage]
     /// <inheritdoc/>
-    public Task<AppwriteResult<Team>> GetTeam(GetTeamRequest request) => throw new NotImplementedException();
+    public async Task<AppwriteResult<Team>> GetTeam(GetTeamRequest request)
+    {
+        try
+        {
+            request.Validate(true);
+
+            var result = await _teamsApi.GetTeam(request.TeamId);
+
+            return result.GetApiResponse();
+        }
+        catch (Exception e)
+        {
+            return e.GetExceptionResponse<Team>();
+        }
+    }
 
     [ExcludeFromCodeCoverage]
     /// <inheritdoc/>

--- a/tests/PinguApps.Appwrite.Client.Tests/Clients/Teams/TeamsClientTests.GetTeam.cs
+++ b/tests/PinguApps.Appwrite.Client.Tests/Clients/Teams/TeamsClientTests.GetTeam.cs
@@ -1,0 +1,97 @@
+﻿using System.Net;
+using PinguApps.Appwrite.Client.Clients;
+using PinguApps.Appwrite.Shared.Requests.Teams;
+using PinguApps.Appwrite.Shared.Tests;
+using PinguApps.Appwrite.Shared.Utils;
+using RichardSzalay.MockHttp;
+
+namespace PinguApps.Appwrite.Client.Tests.Clients.Teams;
+public partial class TeamsClientTests
+{
+    [Fact]
+    public async Task GetTeam_ShouldReturnSuccess_WhenApiCallSucceeds()
+    {
+        // Arrange
+        var request = new GetTeamRequest
+        {
+            TeamId = IdUtils.GenerateUniqueId()
+        };
+
+        _mockHttp.Expect(HttpMethod.Get, $"{TestConstants.Endpoint}/teams/{request.TeamId}")
+            .ExpectedHeaders(true)
+            .Respond(TestConstants.AppJson, TestConstants.TeamResponse);
+
+        _appwriteClient.SetSession(TestConstants.Session);
+
+        // Act
+        var result = await _appwriteClient.Teams.GetTeam(request);
+
+        // Assert
+        Assert.True(result.Success);
+    }
+
+    [Fact]
+    public async Task GetTeam_ShouldReturnError_WhenSessionIsNull()
+    {
+        // Arrange
+        var request = new GetTeamRequest
+        {
+            TeamId = IdUtils.GenerateUniqueId()
+        };
+
+        // Act
+        var result = await _appwriteClient.Teams.GetTeam(request);
+
+        // Assert
+        Assert.True(result.IsError);
+        Assert.True(result.IsInternalError);
+        Assert.Equal(ISessionAware.SessionExceptionMessage, result.Result.AsT2.Message);
+    }
+
+    [Fact]
+    public async Task GetTeam_ShouldHandleException_WhenApiCallFails()
+    {
+        // Arrange
+        var request = new GetTeamRequest
+        {
+            TeamId = IdUtils.GenerateUniqueId()
+        };
+
+        _mockHttp.Expect(HttpMethod.Get, $"{TestConstants.Endpoint}/teams/{request.TeamId}")
+            .ExpectedHeaders(true)
+            .Respond(HttpStatusCode.BadRequest, TestConstants.AppJson, TestConstants.AppwriteError);
+
+        _appwriteClient.SetSession(TestConstants.Session);
+
+        // Act
+        var result = await _appwriteClient.Teams.GetTeam(request);
+
+        // Assert
+        Assert.True(result.IsError);
+        Assert.True(result.IsAppwriteError);
+    }
+
+    [Fact]
+    public async Task GetTeam_ShouldReturnErrorResponse_WhenExceptionOccurs()
+    {
+        // Arrange
+        var request = new GetTeamRequest
+        {
+            TeamId = IdUtils.GenerateUniqueId()
+        };
+
+        _mockHttp.Expect(HttpMethod.Get, $"{TestConstants.Endpoint}/teams/{request.TeamId}")
+            .ExpectedHeaders(true)
+            .Throw(new HttpRequestException("An error occurred"));
+
+        _appwriteClient.SetSession(TestConstants.Session);
+
+        // Act
+        var result = await _appwriteClient.Teams.GetTeam(request);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.True(result.IsInternalError);
+        Assert.Equal("An error occurred", result.Result.AsT2.Message);
+    }
+}

--- a/tests/PinguApps.Appwrite.Server.Tests/Clients/Teams/TeamsClientTests.GetTeam.cs
+++ b/tests/PinguApps.Appwrite.Server.Tests/Clients/Teams/TeamsClientTests.GetTeam.cs
@@ -1,0 +1,72 @@
+﻿using System.Net;
+using PinguApps.Appwrite.Shared.Requests.Teams;
+using PinguApps.Appwrite.Shared.Tests;
+using PinguApps.Appwrite.Shared.Utils;
+using RichardSzalay.MockHttp;
+
+namespace PinguApps.Appwrite.Server.Tests.Clients.Teams;
+public partial class TeamsClientTests
+{
+    [Fact]
+    public async Task GetTeam_ShouldReturnSuccess_WhenApiCallSucceeds()
+    {
+        // Arrange
+        var request = new GetTeamRequest
+        {
+            TeamId = IdUtils.GenerateUniqueId()
+        };
+
+        _mockHttp.Expect(HttpMethod.Get, $"{TestConstants.Endpoint}/teams/{request.TeamId}")
+            .ExpectedHeaders()
+            .Respond(TestConstants.AppJson, TestConstants.TeamResponse);
+
+        // Act
+        var result = await _appwriteClient.Teams.GetTeam(request);
+
+        // Assert
+        Assert.True(result.Success);
+    }
+
+    [Fact]
+    public async Task GetTeam_ShouldHandleException_WhenApiCallFails()
+    {
+        // Arrange
+        var request = new GetTeamRequest
+        {
+            TeamId = IdUtils.GenerateUniqueId()
+        };
+
+        _mockHttp.Expect(HttpMethod.Get, $"{TestConstants.Endpoint}/teams/{request.TeamId}")
+            .ExpectedHeaders()
+            .Respond(HttpStatusCode.BadRequest, TestConstants.AppJson, TestConstants.AppwriteError);
+
+        // Act
+        var result = await _appwriteClient.Teams.GetTeam(request);
+
+        // Assert
+        Assert.True(result.IsError);
+        Assert.True(result.IsAppwriteError);
+    }
+
+    [Fact]
+    public async Task GetTeam_ShouldReturnErrorResponse_WhenExceptionOccurs()
+    {
+        // Arrange
+        var request = new GetTeamRequest
+        {
+            TeamId = IdUtils.GenerateUniqueId()
+        };
+
+        _mockHttp.Expect(HttpMethod.Get, $"{TestConstants.Endpoint}/teams/{request.TeamId}")
+            .ExpectedHeaders()
+            .Throw(new HttpRequestException("An error occurred"));
+
+        // Act
+        var result = await _appwriteClient.Teams.GetTeam(request);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.True(result.IsInternalError);
+        Assert.Equal("An error occurred", result.Result.AsT2.Message);
+    }
+}


### PR DESCRIPTION
# Changes
<!-- Leave this as is, and coderabbitai will summarise your changes for you. -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated team operations to retrieve existing teams instead of creating new ones.
	- Introduced a specific team identifier for retrieval purposes.
	- Added a new `GetTeam` method for both Client and Server SDKs to allow team retrieval by ID.

- **Documentation**
	- Updated README to reflect the implementation status of the "Get Team" endpoint.
	- Incremented progress indicators for Server and Client SDKs in the documentation.

- **Tests**
	- Introduced comprehensive unit tests for the `GetTeam` method in both Client and Server SDKs to validate functionality and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Issue
<!-- Enter the ticket number and link to the issue you are completing, if appropriate -->

## Checklist before requesting a review
> The PR will only be considered when all items within the checklist are marked as complete. Feel free to submit an incomplete draft PR, and add additional commits until you are able to satisfy each item within the checklist.
- [x] I have performed a self-review of my code
- [x] I have submitted at most one additional endpoint implementation
- [x] I have either submitted no additional endpoint implementation, or my implementation covers both client and server SDK's, unless either are marked in the [README](https://github.com/PinguApps/AppwriteSdk/blob/dev/README.md) with a ❌
- [x] I have added applicable tests for my code
- [x] I have updated the [README](https://github.com/PinguApps/AppwriteSdk/blob/dev/README.md) with updated status as a result of this PR
