### PR TITLE
Implemented get team preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,11 +141,11 @@ string emailAddressOrErrorMessage = userResponse.Result.Match(
 
 ## ⌛ Progress
 <!-- `red` for first third, `gold` for second third, `forestgreen` for final third, `blue` for 100% -->
-![Server & Client - 122 / 318](https://img.shields.io/badge/Server_&_Client-122%20%2F%20318-gold?style=for-the-badge)
+![Server & Client - 124 / 318](https://img.shields.io/badge/Server_&_Client-124%20%2F%20318-gold?style=for-the-badge)
 
-![Server - 64 / 225](https://img.shields.io/badge/Server-64%20%2F%20225-red?style=for-the-badge)
+![Server - 65 / 225](https://img.shields.io/badge/Server-65%20%2F%20225-red?style=for-the-badge)
 
-![Client - 58 / 93](https://img.shields.io/badge/Client-58%20%2F%2093-gold?style=for-the-badge)
+![Client - 59 / 93](https://img.shields.io/badge/Client-59%20%2F%2093-gold?style=for-the-badge)
 
 ### 🔑 Key
 | Icon | Definition |
@@ -256,7 +256,7 @@ string emailAddressOrErrorMessage = userResponse.Result.Match(
 | [Update Phone Verification](https://appwrite.io/docs/references/1.6.x/server-rest/users#updatePhoneVerification) | ❌ | ✅ |
 
 ### Teams
-![Teams - 22 / 26](https://img.shields.io/badge/Teams-22%20%2F%2026-gold?style=for-the-badge)
+![Teams - 24 / 26](https://img.shields.io/badge/Teams-24%20%2F%2026-forestgreen?style=for-the-badge)
 
 | Endpoint | Client | Server |
 |:-:|:-:|:-:|
@@ -271,7 +271,7 @@ string emailAddressOrErrorMessage = userResponse.Result.Match(
 | [Update Membership](https://appwrite.io/docs/references/1.6.x/client-rest/teams#updateMembership) | ✅ | ✅ |
 | [Delete Team Membership](https://appwrite.io/docs/references/1.6.x/client-rest/teams#deleteMembership) | ✅ | ✅ |
 | [Update Team Membership Status](https://appwrite.io/docs/references/1.6.x/client-rest/teams#updateMembershipStatus) | ✅ | ✅ |
-| [Get Team Memberships](https://appwrite.io/docs/references/1.6.x/client-rest/teams#getPrefs) | ⬛ | ⬛ |
+| [Get Team Memberships](https://appwrite.io/docs/references/1.6.x/client-rest/teams#getPrefs) | ✅ | ✅ |
 | [Update Preferences](https://appwrite.io/docs/references/1.6.x/client-rest/teams#updatePrefs) | ⬛ | ⬛ |
 
 ### Databases

--- a/src/PinguApps.Appwrite.Client/Clients/ITeamsClient.cs
+++ b/src/PinguApps.Appwrite.Client/Clients/ITeamsClient.cs
@@ -104,7 +104,13 @@ public interface ITeamsClient
     /// <param name="request">The request content</param>
     /// <returns>The membership</returns>
     Task<AppwriteResult<Membership>> UpdateTeamMembershipStatus(UpdateTeamMembershipStatusRequest request);
-    [Obsolete("This method hasn't yet been implemented!")]
+
+    /// <summary>
+    /// Get the team's shared preferences by its unique ID. If a preference doesn't need to be shared by all team members, prefer storing them in <see href="https://appwrite.io/docs/references/cloud/client-web/account#getPrefs">user preferences</see>.
+    /// <para><see href="https://appwrite.io/docs/references/1.6.x/client-rest/teams#getPrefs">Appwrite Docs</see></para>
+    /// </summary>
+    /// <param name="request">The request content</param>
+    /// <returns>The preferences</returns>
     Task<AppwriteResult<IReadOnlyDictionary<string, string>>> GetTeamPreferences(GetTeamPreferencesRequest request);
     [Obsolete("This method hasn't yet been implemented!")]
     Task<AppwriteResult<IReadOnlyDictionary<string, string>>> UpdatePreferences(UpdatePreferencesRequest request);

--- a/src/PinguApps.Appwrite.Client/Clients/TeamsClient.cs
+++ b/src/PinguApps.Appwrite.Client/Clients/TeamsClient.cs
@@ -212,9 +212,22 @@ public class TeamsClient : SessionAwareClientBase, ITeamsClient
         }
     }
 
-    [ExcludeFromCodeCoverage]
     /// <inheritdoc/>
-    public Task<AppwriteResult<IReadOnlyDictionary<string, string>>> GetTeamPreferences(GetTeamPreferencesRequest request) => throw new NotImplementedException();
+    public async Task<AppwriteResult<IReadOnlyDictionary<string, string>>> GetTeamPreferences(GetTeamPreferencesRequest request)
+    {
+        try
+        {
+            request.Validate(true);
+
+            var result = await _teamsApi.GetTeamPreferences(GetCurrentSessionOrThrow(), request.TeamId);
+
+            return result.GetApiResponse();
+        }
+        catch (Exception e)
+        {
+            return e.GetExceptionResponse<IReadOnlyDictionary<string, string>>();
+        }
+    }
 
     [ExcludeFromCodeCoverage]
     /// <inheritdoc/>

--- a/src/PinguApps.Appwrite.Playground/App.cs
+++ b/src/PinguApps.Appwrite.Playground/App.cs
@@ -19,34 +19,21 @@ internal class App
     {
         _client.SetSession(_session);
 
-        var request = new UpdateTeamMembershipStatusRequest()
+        var request = new GetTeamPreferencesRequest()
         {
-            TeamId = "67142b78001c379958cb",
-            MembershipId = "671531b0251d3541ae46",
-            UserId = "67143ec991a30b2a73cb",
-            Secret = "43c2c5f0d3b2aa4f9a519be67f2b866ae8a44f132acd6dba32401cf7c7f1185e9389c8fce3bfa1e8675915bf06a2ccaedc4a756e10fac27f10103111d32a05046301fd689598bb6d25275832be90b4be682b9217ef648d1f01e97be8e10b0a8b4b424fa092e6d987e18fd65a431ed493edad846b2d3709a379e44d1df0870701"
+            TeamId = "67142b78001c379958cb"
         };
 
-        //var clientResponse = await _client.Teams.UpdateTeamMembershipStatus(request);
+        var clientResponse = await _client.Teams.GetTeamPreferences(request);
 
-        //var request = new CreateTeamMembershipRequest()
-        //{
-        //    TeamId = "67142b78001c379958cb",
-        //    Email = "pingu@example.com",
-        //    Name = "TEST",
-        //    Url = "https://localhost:1234/abc"
-        //};
-
-        //var clientResponse = await _client.Teams.CreateTeamMembership(request);
-
-        //Console.WriteLine(clientResponse.Result.Match(
-        //    result => result.ToString(),
-        //    appwriteError => appwriteError.Message,
-        //    internalError => internalError.Message));
+        Console.WriteLine(clientResponse.Result.Match(
+            result => result.ToString(),
+            appwriteError => appwriteError.Message,
+            internalError => internalError.Message));
 
         Console.WriteLine("############################################################################");
 
-        var serverResponse = await _server.Teams.UpdateTeamMembershipStatus(request);
+        var serverResponse = await _server.Teams.GetTeamPreferences(request);
 
         Console.WriteLine(serverResponse.Result.Match(
             result => result.ToString(),

--- a/src/PinguApps.Appwrite.Server/Clients/ITeamsClient.cs
+++ b/src/PinguApps.Appwrite.Server/Clients/ITeamsClient.cs
@@ -105,7 +105,13 @@ public interface ITeamsClient
     /// <returns>The membership</returns>
     [Obsolete("This method on the server SDK currently will not work. You can track this bug on the Appwrite Github: https://github.com/appwrite/appwrite/issues/8828", false)]
     Task<AppwriteResult<Membership>> UpdateTeamMembershipStatus(UpdateTeamMembershipStatusRequest request);
-    [Obsolete("This method hasn't yet been implemented!")]
+
+    /// <summary>
+    /// Get the team's shared preferences by its unique ID. If a preference doesn't need to be shared by all team members, prefer storing them in <see href="https://appwrite.io/docs/references/cloud/client-web/account#getPrefs">user preferences</see>.
+    /// <para><see href="https://appwrite.io/docs/references/1.6.x/server-rest/teams#getPrefs">Appwrite Docs</see></para>
+    /// </summary>
+    /// <param name="request">The request content</param>
+    /// <returns>The preferences</returns>
     Task<AppwriteResult<IReadOnlyDictionary<string, string>>> GetTeamPreferences(GetTeamPreferencesRequest request);
     [Obsolete("This method hasn't yet been implemented!")]
     Task<AppwriteResult<IReadOnlyDictionary<string, string>>> UpdatePreferences(UpdatePreferencesRequest request);

--- a/src/PinguApps.Appwrite.Server/Clients/TeamsClient.cs
+++ b/src/PinguApps.Appwrite.Server/Clients/TeamsClient.cs
@@ -212,9 +212,22 @@ public class TeamsClient : ITeamsClient
         }
     }
 
-    [ExcludeFromCodeCoverage]
     /// <inheritdoc/>
-    public Task<AppwriteResult<IReadOnlyDictionary<string, string>>> GetTeamPreferences(GetTeamPreferencesRequest request) => throw new NotImplementedException();
+    public async Task<AppwriteResult<IReadOnlyDictionary<string, string>>> GetTeamPreferences(GetTeamPreferencesRequest request)
+    {
+        try
+        {
+            request.Validate(true);
+
+            var result = await _teamsApi.GetTeamPreferences(request.TeamId);
+
+            return result.GetApiResponse();
+        }
+        catch (Exception e)
+        {
+            return e.GetExceptionResponse<IReadOnlyDictionary<string, string>>();
+        }
+    }
 
     [ExcludeFromCodeCoverage]
     /// <inheritdoc/>

--- a/tests/PinguApps.Appwrite.Client.Tests/Clients/Teams/TeamsClientTests.GetTeamPreferences.cs
+++ b/tests/PinguApps.Appwrite.Client.Tests/Clients/Teams/TeamsClientTests.GetTeamPreferences.cs
@@ -1,0 +1,97 @@
+﻿using System.Net;
+using PinguApps.Appwrite.Client.Clients;
+using PinguApps.Appwrite.Shared.Requests.Teams;
+using PinguApps.Appwrite.Shared.Tests;
+using PinguApps.Appwrite.Shared.Utils;
+using RichardSzalay.MockHttp;
+
+namespace PinguApps.Appwrite.Client.Tests.Clients.Teams;
+public partial class TeamsClientTests
+{
+    [Fact]
+    public async Task GetTeamPreferences_ShouldReturnSuccess_WhenApiCallSucceeds()
+    {
+        // Arrange
+        var request = new GetTeamPreferencesRequest
+        {
+            TeamId = IdUtils.GenerateUniqueId()
+        };
+
+        _mockHttp.Expect(HttpMethod.Get, $"{TestConstants.Endpoint}/teams/{request.TeamId}/prefs")
+            .ExpectedHeaders(true)
+            .Respond(TestConstants.AppJson, TestConstants.PreferencesResponse);
+
+        _appwriteClient.SetSession(TestConstants.Session);
+
+        // Act
+        var result = await _appwriteClient.Teams.GetTeamPreferences(request);
+
+        // Assert
+        Assert.True(result.Success);
+    }
+
+    [Fact]
+    public async Task GetTeamPreferences_ShouldReturnError_WhenSessionIsNull()
+    {
+        // Arrange
+        var request = new GetTeamPreferencesRequest
+        {
+            TeamId = IdUtils.GenerateUniqueId()
+        };
+
+        // Act
+        var result = await _appwriteClient.Teams.GetTeamPreferences(request);
+
+        // Assert
+        Assert.True(result.IsError);
+        Assert.True(result.IsInternalError);
+        Assert.Equal(ISessionAware.SessionExceptionMessage, result.Result.AsT2.Message);
+    }
+
+    [Fact]
+    public async Task GetTeamPreferences_ShouldHandleException_WhenApiCallFails()
+    {
+        // Arrange
+        var request = new GetTeamPreferencesRequest
+        {
+            TeamId = IdUtils.GenerateUniqueId()
+        };
+
+        _mockHttp.Expect(HttpMethod.Get, $"{TestConstants.Endpoint}/teams/{request.TeamId}/prefs")
+            .ExpectedHeaders(true)
+            .Respond(HttpStatusCode.BadRequest, TestConstants.AppJson, TestConstants.AppwriteError);
+
+        _appwriteClient.SetSession(TestConstants.Session);
+
+        // Act
+        var result = await _appwriteClient.Teams.GetTeamPreferences(request);
+
+        // Assert
+        Assert.True(result.IsError);
+        Assert.True(result.IsAppwriteError);
+    }
+
+    [Fact]
+    public async Task GetTeamPreferences_ShouldReturnErrorResponse_WhenExceptionOccurs()
+    {
+        // Arrange
+        var request = new GetTeamPreferencesRequest
+        {
+            TeamId = IdUtils.GenerateUniqueId()
+        };
+
+        _mockHttp.Expect(HttpMethod.Get, $"{TestConstants.Endpoint}/teams/{request.TeamId}/prefs")
+            .ExpectedHeaders(true)
+            .Throw(new HttpRequestException("An error occurred"));
+
+        _appwriteClient.SetSession(TestConstants.Session);
+
+        // Act
+        var result = await _appwriteClient.Teams.GetTeamPreferences(request);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.True(result.IsInternalError);
+        Assert.Equal("An error occurred", result.Result.AsT2.Message);
+    }
+}

--- a/tests/PinguApps.Appwrite.Server.Tests/Clients/Teams/TeamsClientTests.GetTeamPreferences.cs
+++ b/tests/PinguApps.Appwrite.Server.Tests/Clients/Teams/TeamsClientTests.GetTeamPreferences.cs
@@ -1,0 +1,72 @@
+﻿using System.Net;
+using PinguApps.Appwrite.Shared.Requests.Teams;
+using PinguApps.Appwrite.Shared.Tests;
+using PinguApps.Appwrite.Shared.Utils;
+using RichardSzalay.MockHttp;
+
+namespace PinguApps.Appwrite.Server.Tests.Clients.Teams;
+public partial class TeamsClientTests
+{
+    [Fact]
+    public async Task GetTeamPreferences_ShouldReturnSuccess_WhenApiCallSucceeds()
+    {
+        // Arrange
+        var request = new GetTeamPreferencesRequest
+        {
+            TeamId = IdUtils.GenerateUniqueId()
+        };
+
+        _mockHttp.Expect(HttpMethod.Get, $"{TestConstants.Endpoint}/teams/{request.TeamId}/prefs")
+            .ExpectedHeaders()
+            .Respond(TestConstants.AppJson, TestConstants.PreferencesResponse);
+
+        // Act
+        var result = await _appwriteClient.Teams.GetTeamPreferences(request);
+
+        // Assert
+        Assert.True(result.Success);
+    }
+
+    [Fact]
+    public async Task GetTeamPreferences_ShouldHandleException_WhenApiCallFails()
+    {
+        // Arrange
+        var request = new GetTeamPreferencesRequest
+        {
+            TeamId = IdUtils.GenerateUniqueId()
+        };
+
+        _mockHttp.Expect(HttpMethod.Get, $"{TestConstants.Endpoint}/teams/{request.TeamId}/prefs")
+            .ExpectedHeaders()
+            .Respond(HttpStatusCode.BadRequest, TestConstants.AppJson, TestConstants.AppwriteError);
+
+        // Act
+        var result = await _appwriteClient.Teams.GetTeamPreferences(request);
+
+        // Assert
+        Assert.True(result.IsError);
+        Assert.True(result.IsAppwriteError);
+    }
+
+    [Fact]
+    public async Task GetTeamPreferences_ShouldReturnErrorResponse_WhenExceptionOccurs()
+    {
+        // Arrange
+        var request = new GetTeamPreferencesRequest
+        {
+            TeamId = IdUtils.GenerateUniqueId()
+        };
+
+        _mockHttp.Expect(HttpMethod.Get, $"{TestConstants.Endpoint}/teams/{request.TeamId}/prefs")
+            .ExpectedHeaders()
+            .Throw(new HttpRequestException("An error occurred"));
+
+        // Act
+        var result = await _appwriteClient.Teams.GetTeamPreferences(request);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.True(result.IsInternalError);
+        Assert.Equal("An error occurred", result.Result.AsT2.Message);
+    }
+}


### PR DESCRIPTION
# Changes
<!-- Provide a summary of the changes you have made. -->
- Implemented get team preferences

## Issue
<!-- Enter the ticket number and link to the issue you are completing, if appropriate -->
#314 

## Checklist before requesting a review
> The PR will only be considered when all items within the checklist are marked as complete. Feel free to submit an incomplete draft PR, and add additional commits until you are able to satisfy each item within the checklist.
- [x] I have performed a self-review of my code
- [x] I have submitted at most one additional endpoint implementation
- [x] I have either submitted no additional endpoint implementation, or my implementation covers both client and server SDK's, unless either are marked in the [README](https://github.com/PinguApps/AppwriteSdk/blob/dev/README.md) with a ❌
- [x] I have added applicable tests for my code
- [x] I have updated the [README](https://github.com/PinguApps/AppwriteSdk/blob/dev/README.md) with updated status as a result of this PR

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement the `GetTeamPreferences` method in both the client and server `ITeamsClient` interfaces and their respective `TeamsClient` classes, allowing retrieval of a team's shared preferences by its unique ID.

### Why are these changes being made?

These changes are made to provide functionality for retrieving team preferences, which was previously unimplemented, thereby enhancing the API's capability to manage team-specific settings. This implementation aligns with the Appwrite documentation and addresses a gap in the current feature set, improving the overall utility of the client and server SDKs.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->