### PR TITLE
Implemented Update preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,11 +141,11 @@ string emailAddressOrErrorMessage = userResponse.Result.Match(
 
 ## ⌛ Progress
 <!-- `red` for first third, `gold` for second third, `forestgreen` for final third, `blue` for 100% -->
-![Server & Client - 124 / 318](https://img.shields.io/badge/Server_&_Client-124%20%2F%20318-gold?style=for-the-badge)
+![Server & Client - 126 / 318](https://img.shields.io/badge/Server_&_Client-126%20%2F%20318-gold?style=for-the-badge)
 
-![Server - 65 / 225](https://img.shields.io/badge/Server-65%20%2F%20225-red?style=for-the-badge)
+![Server - 66 / 225](https://img.shields.io/badge/Server-66%20%2F%20225-red?style=for-the-badge)
 
-![Client - 59 / 93](https://img.shields.io/badge/Client-59%20%2F%2093-gold?style=for-the-badge)
+![Client - 60 / 93](https://img.shields.io/badge/Client-60%20%2F%2093-gold?style=for-the-badge)
 
 ### 🔑 Key
 | Icon | Definition |
@@ -256,7 +256,7 @@ string emailAddressOrErrorMessage = userResponse.Result.Match(
 | [Update Phone Verification](https://appwrite.io/docs/references/1.6.x/server-rest/users#updatePhoneVerification) | ❌ | ✅ |
 
 ### Teams
-![Teams - 24 / 26](https://img.shields.io/badge/Teams-24%20%2F%2026-forestgreen?style=for-the-badge)
+![Teams - 26 / 26](https://img.shields.io/badge/Teams-24%20%2F%2026-blue?style=for-the-badge)
 
 | Endpoint | Client | Server |
 |:-:|:-:|:-:|
@@ -272,7 +272,7 @@ string emailAddressOrErrorMessage = userResponse.Result.Match(
 | [Delete Team Membership](https://appwrite.io/docs/references/1.6.x/client-rest/teams#deleteMembership) | ✅ | ✅ |
 | [Update Team Membership Status](https://appwrite.io/docs/references/1.6.x/client-rest/teams#updateMembershipStatus) | ✅ | ✅ |
 | [Get Team Memberships](https://appwrite.io/docs/references/1.6.x/client-rest/teams#getPrefs) | ✅ | ✅ |
-| [Update Preferences](https://appwrite.io/docs/references/1.6.x/client-rest/teams#updatePrefs) | ⬛ | ⬛ |
+| [Update Preferences](https://appwrite.io/docs/references/1.6.x/client-rest/teams#updatePrefs) | ✅ | ✅ |
 
 ### Databases
 ![Databases - 0 / 47](https://img.shields.io/badge/Databases-0%20%2F%2047-red?style=for-the-badge)

--- a/src/PinguApps.Appwrite.Client/Clients/ITeamsClient.cs
+++ b/src/PinguApps.Appwrite.Client/Clients/ITeamsClient.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using PinguApps.Appwrite.Shared;
 using PinguApps.Appwrite.Shared.Requests.Teams;
@@ -112,6 +111,12 @@ public interface ITeamsClient
     /// <param name="request">The request content</param>
     /// <returns>The preferences</returns>
     Task<AppwriteResult<IReadOnlyDictionary<string, string>>> GetTeamPreferences(GetTeamPreferencesRequest request);
-    [Obsolete("This method hasn't yet been implemented!")]
+
+    /// <summary>
+    /// Update the team's preferences by its unique ID. The object you pass is stored as is and replaces any previous value. The maximum allowed prefs size is 64kB and throws an error if exceeded.
+    /// <para><see href="https://appwrite.io/docs/references/1.6.x/client-rest/teams#updatePrefs">Appwrite Docs</see></para>
+    /// </summary>
+    /// <param name="request">The request content</param>
+    /// <returns>The preferences</returns>
     Task<AppwriteResult<IReadOnlyDictionary<string, string>>> UpdatePreferences(UpdatePreferencesRequest request);
 }

--- a/src/PinguApps.Appwrite.Client/Clients/TeamsClient.cs
+++ b/src/PinguApps.Appwrite.Client/Clients/TeamsClient.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using PinguApps.Appwrite.Client.Internals;
@@ -229,7 +228,20 @@ public class TeamsClient : SessionAwareClientBase, ITeamsClient
         }
     }
 
-    [ExcludeFromCodeCoverage]
     /// <inheritdoc/>
-    public Task<AppwriteResult<IReadOnlyDictionary<string, string>>> UpdatePreferences(UpdatePreferencesRequest request) => throw new NotImplementedException();
+    public async Task<AppwriteResult<IReadOnlyDictionary<string, string>>> UpdatePreferences(UpdatePreferencesRequest request)
+    {
+        try
+        {
+            request.Validate(true);
+
+            var result = await _teamsApi.UpdatePreferences(GetCurrentSessionOrThrow(), request.TeamId, request);
+
+            return result.GetApiResponse();
+        }
+        catch (Exception e)
+        {
+            return e.GetExceptionResponse<IReadOnlyDictionary<string, string>>();
+        }
+    }
 }

--- a/src/PinguApps.Appwrite.Playground/App.cs
+++ b/src/PinguApps.Appwrite.Playground/App.cs
@@ -19,21 +19,25 @@ internal class App
     {
         _client.SetSession(_session);
 
-        var request = new GetTeamPreferencesRequest()
+        var request = new UpdatePreferencesRequest()
         {
-            TeamId = "67142b78001c379958cb"
+            TeamId = "67142b78001c379958cb",
+            Preferences = new Dictionary<string, string>()
+            {
+                {"key", "value"}
+            }
         };
 
-        var clientResponse = await _client.Teams.GetTeamPreferences(request);
+        //var clientResponse = await _client.Teams.UpdatePreferences(request);
 
-        Console.WriteLine(clientResponse.Result.Match(
-            result => result.ToString(),
-            appwriteError => appwriteError.Message,
-            internalError => internalError.Message));
+        //Console.WriteLine(clientResponse.Result.Match(
+        //    result => result.ToString(),
+        //    appwriteError => appwriteError.Message,
+        //    internalError => internalError.Message));
 
         Console.WriteLine("############################################################################");
 
-        var serverResponse = await _server.Teams.GetTeamPreferences(request);
+        var serverResponse = await _server.Teams.UpdatePreferences(request);
 
         Console.WriteLine(serverResponse.Result.Match(
             result => result.ToString(),

--- a/src/PinguApps.Appwrite.Server/Clients/ITeamsClient.cs
+++ b/src/PinguApps.Appwrite.Server/Clients/ITeamsClient.cs
@@ -113,6 +113,12 @@ public interface ITeamsClient
     /// <param name="request">The request content</param>
     /// <returns>The preferences</returns>
     Task<AppwriteResult<IReadOnlyDictionary<string, string>>> GetTeamPreferences(GetTeamPreferencesRequest request);
-    [Obsolete("This method hasn't yet been implemented!")]
+
+    /// <summary>
+    /// Update the team's preferences by its unique ID. The object you pass is stored as is and replaces any previous value. The maximum allowed prefs size is 64kB and throws an error if exceeded.
+    /// <para><see href="https://appwrite.io/docs/references/1.6.x/server-rest/teams#updatePrefs">Appwrite Docs</see></para>
+    /// </summary>
+    /// <param name="request">The request content</param>
+    /// <returns>The preferences</returns>
     Task<AppwriteResult<IReadOnlyDictionary<string, string>>> UpdatePreferences(UpdatePreferencesRequest request);
 }

--- a/src/PinguApps.Appwrite.Server/Clients/TeamsClient.cs
+++ b/src/PinguApps.Appwrite.Server/Clients/TeamsClient.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using PinguApps.Appwrite.Server.Internals;
@@ -229,7 +228,20 @@ public class TeamsClient : ITeamsClient
         }
     }
 
-    [ExcludeFromCodeCoverage]
     /// <inheritdoc/>
-    public Task<AppwriteResult<IReadOnlyDictionary<string, string>>> UpdatePreferences(UpdatePreferencesRequest request) => throw new NotImplementedException();
+    public async Task<AppwriteResult<IReadOnlyDictionary<string, string>>> UpdatePreferences(UpdatePreferencesRequest request)
+    {
+        try
+        {
+            request.Validate(true);
+
+            var result = await _teamsApi.UpdatePreferences(request.TeamId, request);
+
+            return result.GetApiResponse();
+        }
+        catch (Exception e)
+        {
+            return e.GetExceptionResponse<IReadOnlyDictionary<string, string>>();
+        }
+    }
 }

--- a/tests/PinguApps.Appwrite.Client.Tests/Clients/Teams/TeamsClientTests.UpdatePreferences.cs
+++ b/tests/PinguApps.Appwrite.Client.Tests/Clients/Teams/TeamsClientTests.UpdatePreferences.cs
@@ -1,0 +1,120 @@
+﻿using System.Net;
+using PinguApps.Appwrite.Client.Clients;
+using PinguApps.Appwrite.Shared.Requests.Teams;
+using PinguApps.Appwrite.Shared.Tests;
+using PinguApps.Appwrite.Shared.Utils;
+using RichardSzalay.MockHttp;
+
+namespace PinguApps.Appwrite.Client.Tests.Clients.Teams;
+public partial class TeamsClientTests
+{
+    [Fact]
+    public async Task UpdatePreferences_ShouldReturnSuccess_WhenApiCallSucceeds()
+    {
+        // Arrange
+        var request = new UpdatePreferencesRequest
+        {
+            TeamId = IdUtils.GenerateUniqueId(),
+            Preferences = new Dictionary<string, string>
+            {
+                { "key1", "value1" },
+                { "key2", "value2" }
+            }
+        };
+
+        _mockHttp.Expect(HttpMethod.Put, $"{TestConstants.Endpoint}/teams/{request.TeamId}/prefs")
+            .ExpectedHeaders(true)
+            .WithJsonContent(request, _jsonSerializerOptions)
+            .Respond(TestConstants.AppJson, TestConstants.PreferencesResponse);
+
+        _appwriteClient.SetSession(TestConstants.Session);
+
+        // Act
+        var result = await _appwriteClient.Teams.UpdatePreferences(request);
+
+        // Assert
+        Assert.True(result.Success);
+    }
+
+    [Fact]
+    public async Task UpdatePreferences_ShouldReturnError_WhenSessionIsNull()
+    {
+        // Arrange
+        var request = new UpdatePreferencesRequest
+        {
+            TeamId = IdUtils.GenerateUniqueId(),
+            Preferences = new Dictionary<string, string>
+            {
+                { "key1", "value1" },
+                { "key2", "value2" }
+            }
+        };
+
+        // Act
+        var result = await _appwriteClient.Teams.UpdatePreferences(request);
+
+        // Assert
+        Assert.True(result.IsError);
+        Assert.True(result.IsInternalError);
+        Assert.Equal(ISessionAware.SessionExceptionMessage, result.Result.AsT2.Message);
+    }
+
+    [Fact]
+    public async Task UpdatePreferences_ShouldHandleException_WhenApiCallFails()
+    {
+        // Arrange
+        var request = new UpdatePreferencesRequest
+        {
+            TeamId = IdUtils.GenerateUniqueId(),
+            Preferences = new Dictionary<string, string>
+            {
+                { "key1", "value1" },
+                { "key2", "value2" }
+            }
+        };
+
+        _mockHttp.Expect(HttpMethod.Put, $"{TestConstants.Endpoint}/teams/{request.TeamId}/prefs")
+            .ExpectedHeaders(true)
+            .WithJsonContent(request, _jsonSerializerOptions)
+            .Respond(HttpStatusCode.BadRequest, TestConstants.AppJson, TestConstants.AppwriteError);
+
+        _appwriteClient.SetSession(TestConstants.Session);
+
+        // Act
+        var result = await _appwriteClient.Teams.UpdatePreferences(request);
+
+        // Assert
+        Assert.True(result.IsError);
+        Assert.True(result.IsAppwriteError);
+    }
+
+    [Fact]
+    public async Task UpdatePreferences_ShouldReturnErrorResponse_WhenExceptionOccurs()
+    {
+        // Arrange
+        var request = new UpdatePreferencesRequest
+        {
+            TeamId = IdUtils.GenerateUniqueId(),
+            Preferences = new Dictionary<string, string>
+            {
+                { "key1", "value1" },
+                { "key2", "value2" }
+            }
+        };
+
+        _mockHttp.Expect(HttpMethod.Put, $"{TestConstants.Endpoint}/teams/{request.TeamId}/prefs")
+            .ExpectedHeaders(true)
+            .WithJsonContent(request, _jsonSerializerOptions)
+            .Throw(new HttpRequestException("An error occurred"));
+
+        _appwriteClient.SetSession(TestConstants.Session);
+
+        // Act
+        var result = await _appwriteClient.Teams.UpdatePreferences(request);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.True(result.IsInternalError);
+        Assert.Equal("An error occurred", result.Result.AsT2.Message);
+    }
+}

--- a/tests/PinguApps.Appwrite.Server.Tests/Clients/Teams/TeamsClientTests.UpdatePreferences.cs
+++ b/tests/PinguApps.Appwrite.Server.Tests/Clients/Teams/TeamsClientTests.UpdatePreferences.cs
@@ -1,0 +1,90 @@
+﻿using System.Net;
+using PinguApps.Appwrite.Shared.Requests.Teams;
+using PinguApps.Appwrite.Shared.Tests;
+using PinguApps.Appwrite.Shared.Utils;
+using RichardSzalay.MockHttp;
+
+namespace PinguApps.Appwrite.Server.Tests.Clients.Teams;
+public partial class TeamsClientTests
+{
+    [Fact]
+    public async Task UpdatePreferences_ShouldReturnSuccess_WhenApiCallSucceeds()
+    {
+        // Arrange
+        var request = new UpdatePreferencesRequest
+        {
+            TeamId = IdUtils.GenerateUniqueId(),
+            Preferences = new Dictionary<string, string>
+            {
+                { "key1", "value1" },
+                { "key2", "value2" }
+            }
+        };
+
+        _mockHttp.Expect(HttpMethod.Put, $"{TestConstants.Endpoint}/teams/{request.TeamId}/prefs")
+            .ExpectedHeaders()
+            .WithJsonContent(request, _jsonSerializerOptions)
+            .Respond(TestConstants.AppJson, TestConstants.PreferencesResponse);
+
+        // Act
+        var result = await _appwriteClient.Teams.UpdatePreferences(request);
+
+        // Assert
+        Assert.True(result.Success);
+    }
+
+    [Fact]
+    public async Task UpdatePreferences_ShouldHandleException_WhenApiCallFails()
+    {
+        // Arrange
+        var request = new UpdatePreferencesRequest
+        {
+            TeamId = IdUtils.GenerateUniqueId(),
+            Preferences = new Dictionary<string, string>
+            {
+                { "key1", "value1" },
+                { "key2", "value2" }
+            }
+        };
+
+        _mockHttp.Expect(HttpMethod.Put, $"{TestConstants.Endpoint}/teams/{request.TeamId}/prefs")
+            .ExpectedHeaders()
+            .WithJsonContent(request, _jsonSerializerOptions)
+            .Respond(HttpStatusCode.BadRequest, TestConstants.AppJson, TestConstants.AppwriteError);
+
+        // Act
+        var result = await _appwriteClient.Teams.UpdatePreferences(request);
+
+        // Assert
+        Assert.True(result.IsError);
+        Assert.True(result.IsAppwriteError);
+    }
+
+    [Fact]
+    public async Task UpdatePreferences_ShouldReturnErrorResponse_WhenExceptionOccurs()
+    {
+        // Arrange
+        var request = new UpdatePreferencesRequest
+        {
+            TeamId = IdUtils.GenerateUniqueId(),
+            Preferences = new Dictionary<string, string>
+            {
+                { "key1", "value1" },
+                { "key2", "value2" }
+            }
+        };
+
+        _mockHttp.Expect(HttpMethod.Put, $"{TestConstants.Endpoint}/teams/{request.TeamId}/prefs")
+            .ExpectedHeaders()
+            .WithJsonContent(request, _jsonSerializerOptions)
+            .Throw(new HttpRequestException("An error occurred"));
+
+        // Act
+        var result = await _appwriteClient.Teams.UpdatePreferences(request);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.True(result.IsInternalError);
+        Assert.Equal("An error occurred", result.Result.AsT2.Message);
+    }
+}


### PR DESCRIPTION
# Changes
<!-- Provide a summary of the changes you have made. -->
- Implemented Update preferences

## Issue
<!-- Enter the ticket number and link to the issue you are completing, if appropriate -->
#315 

## Checklist before requesting a review
> The PR will only be considered when all items within the checklist are marked as complete. Feel free to submit an incomplete draft PR, and add additional commits until you are able to satisfy each item within the checklist.
- [x] I have performed a self-review of my code
- [x] I have submitted at most one additional endpoint implementation
- [x] I have either submitted no additional endpoint implementation, or my implementation covers both client and server SDK's, unless either are marked in the [README](https://github.com/PinguApps/AppwriteSdk/blob/dev/README.md) with a ❌
- [x] I have added applicable tests for my code
- [x] I have updated the [README](https://github.com/PinguApps/AppwriteSdk/blob/dev/README.md) with updated status as a result of this PR

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement the `UpdatePreferences` method for both client and server `TeamsClient` interfaces to allow updating team preferences by their unique ID.

### Why are these changes being made?

These changes are made to provide functionality for updating team preferences, which was previously marked as not implemented. This implementation allows users to update preferences, replacing any previous values, and ensures that the preferences size does not exceed 64kB, aligning with the Appwrite documentation.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->