### PR TITLE
Add auto labelling to prs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,11 +6,10 @@
 
 ## Categorise the PR
 <!-- Select at least one category from below that best describes this PR and what it does -->
-- [ ] feature
-- [ ] bug
-- [ ] docs
-- [ ] meta
-
-- [ ] patch
-- [ ] minor
-- [ ] major
+- [ ] `feature`
+- [ ] `bug`
+- [ ] `docs`
+- [ ] `meta`
+- [ ] `patch`
+- [ ] `minor`
+- [ ] `major`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,7 @@
 - [ ] `feature`
 - [ ] `bug`
 - [ ] `docs`
+- [ ] `meta`
 
 - [ ] `patch`
 - [ ] `minor`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,11 +6,11 @@
 
 ## Categorise the PR
 <!-- Select at least one category from below that best describes this PR and what it does -->
-- [ ] `feature`
-- [ ] `bug`
-- [ ] `docs`
-- [ ] `meta`
+- [ ] feature
+- [ ] bug
+- [ ] docs
+- [ ] meta
 
-- [ ] `patch`
-- [ ] `minor`
-- [ ] `major`
+- [ ] patch
+- [ ] minor
+- [ ] major

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,10 +4,12 @@
 ## Issue
 <!-- Enter the ticket number and link to the issue you are completing, if appropriate -->
 
-## Checklist before requesting a review
-> The PR will only be considered when all items within the checklist are marked as complete. Feel free to submit an incomplete draft PR, and add additional commits until you are able to satisfy each item within the checklist.
-- [ ] I have performed a self-review of my code
-- [ ] I have submitted at most one additional endpoint implementation
-- [ ] I have either submitted no additional endpoint implementation, or my implementation covers both client and server SDK's, unless either are marked in the [README](https://github.com/PinguApps/AppwriteSdk/blob/dev/README.md) with a ❌
-- [ ] I have added applicable tests for my code
-- [ ] I have updated the [README](https://github.com/PinguApps/AppwriteSdk/blob/dev/README.md) with updated status as a result of this PR
+## Categorise the PR
+<!-- Select at least one category from below that best describes this PR and what it does -->
+- [ ] `feature`
+- [ ] `bug`
+- [ ] `docs`
+
+- [ ] `patch`
+- [ ] `minor`
+- [ ] `major`

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -16,6 +16,9 @@ categories:
     labels:
       - "docs"
       - "documentation"
+  - title: "🔗 Dependencies"
+    labels:
+      - "3Adependencies"
 version-resolver:
   major:
     labels:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -18,7 +18,10 @@ categories:
       - "documentation"
   - title: "🔗 Dependencies"
     labels:
-      - "3Adependencies"
+      - "dependencies"
+  - title: "🌀 Meta"
+    labels:
+      - "meta"
 version-resolver:
   major:
     labels:

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,0 +1,20 @@
+name: Auto Labeller
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+
+jobs:
+  labelling:
+    name: Labelling
+    runs-on: ubuntu-linux
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout
+
+      - uses: harupy/auto-labeling@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          label-pattern: '- \[(.*?)\] ?`(.+?)`' # matches '- [x] `label`'

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   labelling:
     name: Labelling
-    runs-on: ubuntu-linux
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         name: Checkout
@@ -17,4 +17,4 @@ jobs:
       - uses: harupy/auto-labeling@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          label-pattern: '- \[(.*?)\] ?`(.+?)`' # matches '- [x] `label`'
+          label-pattern: '- \[(.*?)\] ?(.+?)' # matches '- [x] `label`'

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -17,4 +17,4 @@ jobs:
       - uses: harupy/auto-labeling@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          label-pattern: '- \[(.*?)\] ?(.+?)' # matches '- [x] `label`'
+          label-pattern: '- \[(.*?)\] ?`(.+?)`' # matches '- [x] `label`'


### PR DESCRIPTION
# Changes
<!-- Provide a summary of the changes you have made. -->
- Add auto labelling to prs

## Issue
<!-- Enter the ticket number and link to the issue you are completing, if appropriate -->
#510 

## Categorise the PR
<!-- Select at least one category from below that best describes this PR and what it does -->
- [ ] `feature`
- [ ] `bug`
- [ ] `docs`
- [x] `meta`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add auto-labeling functionality to pull requests by introducing a new GitHub workflow that categorizes PRs based on predefined labels in the pull request template.

### Why are these changes being made?

Automating the labeling process of pull requests ensures that contributions are consistently categorized, saving time for reviewers and maintainers. It enhances project management by providing clear visibility on the type of changes being contributed, which aids in better versioning and release drafting.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->