### PR TITLE
added stale action, running twice a day

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,19 @@
+name: 'Stale issues & PRs'
+on:
+  schedule:
+    - cron: '27 0,12 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 7
+          days-before-pr-stale: 2
+          days-before-close: 3
+          stale-issue-message: 'This issue has been marked as stale, and will be automatically closed in 3 days.'
+          stale-pr-message: 'This PR has been marked as stale, and will be automatically closed in 3 days.'
+          close-issue-message: 'Closing issue as it has been marked as stale for 3 days.'
+          close-pr-message: 'Closing PR as it has been marked as stale for 3 days.'
+          exempt-all-milestones: true


### PR DESCRIPTION
# Changes
<!-- Provide a summary of the changes you have made. -->
- added stale action, running twice a day

## Issue
<!-- Enter the ticket number and link to the issue you are completing, if appropriate -->
#520 

## Categorise the PR
<!-- Select at least one category from below that best describes this PR and what it does -->
- [ ] `feature`
- [ ] `bug`
- [ ] `docs`
- [x] `meta`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a GitHub Actions workflow to identify and mark stale issues and pull requests, scheduled to run twice daily.

### Why are these changes being made?

This change automates the management of stale issues and pull requests by marking them after a period of inactivity and eventually closing them. This helps maintain a tidy and manageable repository by ensuring that inactive items do not reside indefinitely without attention, and running it twice daily ensures it catches stale items promptly.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->