### PR TITLE
Changed private references to shared model to enable ability to reference public classes again

### DIFF
--- a/src/PinguApps.Appwrite.Client/PinguApps.Appwrite.Client.csproj
+++ b/src/PinguApps.Appwrite.Client/PinguApps.Appwrite.Client.csproj
@@ -32,7 +32,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\PinguApps.Appwrite.Shared\PinguApps.Appwrite.Shared.csproj" PrivateAssets="All" />
+    <ProjectReference Include="..\PinguApps.Appwrite.Shared\PinguApps.Appwrite.Shared.csproj">
+      <PrivateAssets>runtime; build; native; contentfiles; analyzers</PrivateAssets>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PinguApps.Appwrite.Server/PinguApps.Appwrite.Server.csproj
+++ b/src/PinguApps.Appwrite.Server/PinguApps.Appwrite.Server.csproj
@@ -32,7 +32,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\PinguApps.Appwrite.Shared\PinguApps.Appwrite.Shared.csproj" PrivateAssets="All" />
+    <ProjectReference Include="..\PinguApps.Appwrite.Shared\PinguApps.Appwrite.Shared.csproj">
+      <PrivateAssets>runtime; build; native; contentfiles; analyzers</PrivateAssets>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PinguApps.Appwrite.Shared/Constants.cs
+++ b/src/PinguApps.Appwrite.Shared/Constants.cs
@@ -1,5 +1,5 @@
 ﻿namespace PinguApps.Appwrite.Shared;
 public static class Constants
 {
-    public const string Version = "0.4.2";
+    public const string Version = "0.4.3";
 }


### PR DESCRIPTION
# Changes
<!-- Provide a summary of the changes you have made. -->
- Changed private references to shared model to enable ability to reference public classes again

## Issue
<!-- Enter the ticket number and link to the issue you are completing, if appropriate -->
- Resolves #573 

## Categorise the PR
<!-- Select at least one category from below that best describes this PR and what it does -->
- [ ] `feature`
- [x] `bug`
- [ ] `docs`
- [ ] `security`
- [ ] `meta`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI


### What change is being made?

Update project references in `PinguApps.Appwrite.Client.csproj` and `PinguApps.Appwrite.Server.csproj` from private to shared assets to allow referencing public classes in shared model and increment the version in `Constants.cs`.

### Why are these changes being made?

The changes enable the ability to reference public classes from the shared model by adjusting the `PrivateAssets` attribute, which better facilitates code reuse and reduces redundancy. The version update in `Constants.cs` reflects these modifications in the shared model configuration.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->