### PR TITLE
586 Ensured that config is only ever accessed as a keyed service to prevent it being overwritten

### DIFF
--- a/src/PinguApps.Appwrite.Client/Clients/AccountClient.cs
+++ b/src/PinguApps.Appwrite.Client/Clients/AccountClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using PinguApps.Appwrite.Client.Clients;
 using PinguApps.Appwrite.Client.Internals;
 using PinguApps.Appwrite.Client.Utils;
@@ -16,7 +17,7 @@ public class AccountClient : SessionAwareClientBase, IAccountClient
     private readonly IAccountApi _accountApi;
     private readonly Config _config;
 
-    internal AccountClient(IAccountApi accountApi, Config config)
+    internal AccountClient(IAccountApi accountApi, [FromKeyedServices("Client")] Config config)
     {
         _accountApi = accountApi;
         _config = config;

--- a/src/PinguApps.Appwrite.Client/Clients/TeamsClient.cs
+++ b/src/PinguApps.Appwrite.Client/Clients/TeamsClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using PinguApps.Appwrite.Client.Internals;
 using PinguApps.Appwrite.Client.Utils;
 using PinguApps.Appwrite.Shared;
@@ -16,7 +17,7 @@ public class TeamsClient : SessionAwareClientBase, ITeamsClient
     private readonly ITeamsApi _teamsApi;
     private readonly Config _config;
 
-    internal TeamsClient(ITeamsApi teamsApi, Config config)
+    internal TeamsClient(ITeamsApi teamsApi, [FromKeyedServices("Client")] Config config)
     {
         _teamsApi = teamsApi;
         _config = config;

--- a/src/PinguApps.Appwrite.Client/Handlers/HeaderHandler.cs
+++ b/src/PinguApps.Appwrite.Client/Handlers/HeaderHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using PinguApps.Appwrite.Shared;
 
 namespace PinguApps.Appwrite.Client.Handlers;
@@ -8,7 +9,7 @@ internal class HeaderHandler : DelegatingHandler
 {
     private readonly string _projectId;
 
-    public HeaderHandler(Config config)
+    public HeaderHandler([FromKeyedServices("Client")] Config config)
     {
         _projectId = config.ProjectId;
     }

--- a/src/PinguApps.Appwrite.Client/ServiceCollectionExtensions.cs
+++ b/src/PinguApps.Appwrite.Client/ServiceCollectionExtensions.cs
@@ -30,7 +30,7 @@ public static class ServiceCollectionExtensions
     {
         var customRefitSettings = AddSerializationConfigToRefitSettings(refitSettings);
 
-        services.AddSingleton(new Config(endpoint, projectId));
+        services.AddKeyedSingleton("Client", new Config(endpoint, projectId));
         services.AddTransient<HeaderHandler>();
         services.AddTransient<ClientCookieSessionHandler>();
 
@@ -52,13 +52,13 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IAccountClient>(sp =>
         {
             var api = sp.GetRequiredService<IAccountApi>();
-            var config = sp.GetRequiredService<Config>();
+            var config = sp.GetRequiredKeyedService<Config>("Client");
             return new AccountClient(api, config);
         });
         services.AddSingleton<ITeamsClient>(sp =>
         {
             var api = sp.GetRequiredService<ITeamsApi>();
-            var config = sp.GetRequiredService<Config>();
+            var config = sp.GetRequiredKeyedService<Config>("Client");
             return new TeamsClient(api, config);
         });
         services.AddSingleton<IDatabasesClient>(sp =>
@@ -84,7 +84,7 @@ public static class ServiceCollectionExtensions
     {
         var customRefitSettings = AddSerializationConfigToRefitSettings(refitSettings);
 
-        services.AddSingleton(new Config(endpoint, projectId));
+        services.AddKeyedSingleton("Client", new Config(endpoint, projectId));
         services.AddTransient<HeaderHandler>();
 
         services.AddRefitClient<IAccountApi>(customRefitSettings)
@@ -105,13 +105,13 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IAccountClient>(sp =>
         {
             var api = sp.GetRequiredService<IAccountApi>();
-            var config = sp.GetRequiredService<Config>();
+            var config = sp.GetRequiredKeyedService<Config>("Client");
             return new AccountClient(api, config);
         });
         services.AddSingleton<ITeamsClient>(sp =>
         {
             var api = sp.GetRequiredService<ITeamsApi>();
-            var config = sp.GetRequiredService<Config>();
+            var config = sp.GetRequiredKeyedService<Config>("Client");
             return new TeamsClient(api, config);
         });
         services.AddSingleton<IDatabasesClient>(sp =>

--- a/src/PinguApps.Appwrite.Server/Clients/AccountClient.cs
+++ b/src/PinguApps.Appwrite.Server/Clients/AccountClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using PinguApps.Appwrite.Server.Internals;
 using PinguApps.Appwrite.Server.Utils;
 using PinguApps.Appwrite.Shared;
@@ -15,7 +16,7 @@ public class AccountClient : IAccountClient
 
     private readonly Config _config;
 
-    internal AccountClient(IAccountApi accountApi, Config config)
+    internal AccountClient(IAccountApi accountApi, [FromKeyedServices("Server")] Config config)
     {
         _accountApi = accountApi;
         _config = config;

--- a/src/PinguApps.Appwrite.Server/Clients/TeamsClient.cs
+++ b/src/PinguApps.Appwrite.Server/Clients/TeamsClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using PinguApps.Appwrite.Server.Internals;
 using PinguApps.Appwrite.Server.Utils;
 using PinguApps.Appwrite.Shared;
@@ -16,7 +17,7 @@ public class TeamsClient : ITeamsClient
     private readonly ITeamsApi _teamsApi;
     private readonly Config _config;
 
-    internal TeamsClient(ITeamsApi teamsApi, Config config)
+    internal TeamsClient(ITeamsApi teamsApi, [FromKeyedServices("Server")] Config config)
     {
         _teamsApi = teamsApi;
         _config = config;

--- a/src/PinguApps.Appwrite.Server/Clients/UsersClient.cs
+++ b/src/PinguApps.Appwrite.Server/Clients/UsersClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using PinguApps.Appwrite.Server.Internals;
 using PinguApps.Appwrite.Server.Utils;
 using PinguApps.Appwrite.Shared;
@@ -15,7 +16,7 @@ public class UsersClient : IUsersClient
     private readonly IUsersApi _usersApi;
     private readonly Config _config;
 
-    internal UsersClient(IUsersApi usersApi, Config config)
+    internal UsersClient(IUsersApi usersApi, [FromKeyedServices("Server")] Config config)
     {
         _usersApi = usersApi;
         _config = config;

--- a/src/PinguApps.Appwrite.Server/Handlers/HeaderHandler.cs
+++ b/src/PinguApps.Appwrite.Server/Handlers/HeaderHandler.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using PinguApps.Appwrite.Shared;
 
 namespace PinguApps.Appwrite.Server.Handlers;
@@ -10,7 +11,7 @@ internal class HeaderHandler : DelegatingHandler
     private readonly string _projectId;
     private readonly string _apiKey;
 
-    public HeaderHandler(Config config)
+    public HeaderHandler([FromKeyedServices("Server")] Config config)
     {
         if (config.ApiKey is null)
             throw new ArgumentNullException("config.ApiKey");

--- a/src/PinguApps.Appwrite.Server/ServiceCollectionExtensions.cs
+++ b/src/PinguApps.Appwrite.Server/ServiceCollectionExtensions.cs
@@ -31,7 +31,7 @@ public static class ServiceCollectionExtensions
     {
         var customRefitSettings = AddSerializationConfigToRefitSettings(refitSettings);
 
-        services.AddSingleton(new Config(endpoint, projectId, apiKey));
+        services.AddKeyedSingleton("Server", new Config(endpoint, projectId, apiKey));
         services.AddTransient<HeaderHandler>();
 
         services.AddRefitClient<IAccountApi>(customRefitSettings)
@@ -57,19 +57,19 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IAccountClient>(sp =>
         {
             var api = sp.GetRequiredService<IAccountApi>();
-            var config = sp.GetRequiredService<Config>();
+            var config = sp.GetRequiredKeyedService<Config>("Server");
             return new AccountClient(api, config);
         });
         services.AddSingleton<IUsersClient>(sp =>
         {
             var api = sp.GetRequiredService<IUsersApi>();
-            var config = sp.GetRequiredService<Config>();
+            var config = sp.GetRequiredKeyedService<Config>("Server");
             return new UsersClient(api, config);
         });
         services.AddSingleton<ITeamsClient>(sp =>
         {
             var api = sp.GetRequiredService<ITeamsApi>();
-            var config = sp.GetRequiredService<Config>();
+            var config = sp.GetRequiredKeyedService<Config>("Server");
             return new TeamsClient(api, config);
         });
         services.AddSingleton<IDatabasesClient>(sp =>

--- a/src/PinguApps.Appwrite.Shared/Constants.cs
+++ b/src/PinguApps.Appwrite.Shared/Constants.cs
@@ -1,5 +1,5 @@
 ﻿namespace PinguApps.Appwrite.Shared;
 public static class Constants
 {
-    public const string Version = "0.4.5";
+    public const string Version = "0.4.6";
 }


### PR DESCRIPTION
# Changes
<!-- Provide a summary of the changes you have made. -->
- Ensured that config is only ever accessed as a keyed service to prevent it being overwritten

## Issue
<!-- Enter the ticket number and link to the issue you are completing, if appropriate -->
- Resolves #586 

## Categorise the PR
<!-- Select at least one category from below that best describes this PR and what it does -->
- [ ] `feature`
- [x] `bug`
- [ ] `docs`
- [ ] `security`
- [ ] `meta`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Ensure that `Config` is accessed as a keyed service in both client and server implementations, and update version number from `0.4.5` to `0.4.6` in `Constants`.

### Why are these changes being made?

These changes prevent the `Config` object from being accidentally overwritten by ensuring it is accessed via a keyed service, which can prevent conflicts and enhance maintainability. The version increase reflects this internal change in the service management strategy.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->