### PR TITLE
Applied a fix serializing documents

### DIFF
--- a/src/PinguApps.Appwrite.Shared/Constants.cs
+++ b/src/PinguApps.Appwrite.Shared/Constants.cs
@@ -1,5 +1,5 @@
 ﻿namespace PinguApps.Appwrite.Shared;
 public static class Constants
 {
-    public const string Version = "1.0.1";
+    public const string Version = "1.0.2";
 }

--- a/src/PinguApps.Appwrite.Shared/Converters/DocumentConverter.cs
+++ b/src/PinguApps.Appwrite.Shared/Converters/DocumentConverter.cs
@@ -185,7 +185,14 @@ public class DocumentConverter : JsonConverter<Document>
         dateTimeConverter.Write(writer, value.UpdatedAt, options);
 
         writer.WritePropertyName("$permissions");
-        JsonSerializer.Serialize(writer, value.Permissions, options);
+        if (value.Permissions is null)
+        {
+            writer.WriteNullValue();
+        }
+        else
+        {
+            JsonSerializer.Serialize(writer, value.Permissions, options);
+        }
 
         // Write dynamic properties from the Data dictionary
         foreach (var kvp in value.Data)

--- a/src/PinguApps.Appwrite.Shared/Converters/DocumentGenericConverter.cs
+++ b/src/PinguApps.Appwrite.Shared/Converters/DocumentGenericConverter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using PinguApps.Appwrite.Shared.Responses;
@@ -199,7 +198,14 @@ public class DocumentGenericConverter<TData> : JsonConverter<Document<TData>>
         dateTimeConverter.Write(writer, value.UpdatedAt, options);
 
         writer.WritePropertyName("$permissions");
-        permissionsListConverter.Write(writer, value.Permissions.ToList(), options);
+        if (value.Permissions is null)
+        {
+            writer.WriteNullValue();
+        }
+        else
+        {
+            permissionsListConverter.Write(writer, [.. value.Permissions], options);
+        }
 
         // Serialize the Data property
         if (value.Data is not null)

--- a/tests/PinguApps.Appwrite.Shared.Tests/Converters/DocumentConverterTests.cs
+++ b/tests/PinguApps.Appwrite.Shared.Tests/Converters/DocumentConverterTests.cs
@@ -430,4 +430,33 @@ public class DocumentConverterTests
 
         Assert.Contains("\"objectField\":{}}", json);
     }
+
+    [Fact]
+    public void Write_NullPermissions_WritesNull()
+    {
+        var document = new Document(
+            "1",
+            "col1",
+            "db1",
+            DateTime.Parse("2020-10-15T06:38:00.000+00:00"),
+            DateTime.Parse("2020-10-15T06:38:00.000+00:00"),
+            null,
+            new Dictionary<string, object?> { { "customField", "customValue" } }
+        );
+
+        var json = JsonSerializer.Serialize(document, _options);
+
+        var expectedJson = @"
+            {
+                ""$id"": ""1"",
+                ""$collectionId"": ""col1"",
+                ""$databaseId"": ""db1"",
+                ""$createdAt"": ""2020-10-15T06:38:00.000+00:00"",
+                ""$updatedAt"": ""2020-10-15T06:38:00.000+00:00"",
+                ""$permissions"": null,
+                ""customField"": ""customValue""
+            }".ReplaceLineEndings("").Replace(" ", "");
+
+        Assert.Equal(JsonDocument.Parse(expectedJson).RootElement.ToString(), JsonDocument.Parse(json).RootElement.ToString());
+    }
 }

--- a/tests/PinguApps.Appwrite.Shared.Tests/Converters/DocumentGenericConverterTests.cs
+++ b/tests/PinguApps.Appwrite.Shared.Tests/Converters/DocumentGenericConverterTests.cs
@@ -553,4 +553,51 @@ public class DocumentGenericConverterTests
         Assert.Equal(JsonValueKind.Number, doubleFieldElement.ValueKind);
         Assert.Equal(1.23e20, doubleFieldElement.GetDouble());
     }
+
+    [Fact]
+    public void Write_NullPermissions_WritesNull()
+    {
+        var testData = new TestData
+        {
+            Field1 = "value1",
+            Field2 = 42,
+            Field3 = true,
+            Field4 = DateTime.Parse("2020-10-15T06:38:00.000+00:00"),
+            Field5 = ["item1", "item2"],
+            Field6 = new Dictionary<string, object?> { { "key1", "value1" }, { "key2", 2 } }
+        };
+
+        var document = new Document<TestData>(
+            "1",
+            "col1",
+            "db1",
+            DateTime.Parse("2020-10-15T06:38:00.000+00:00"),
+            DateTime.Parse("2020-10-15T06:38:00.000+00:00"),
+            null,
+            testData
+        );
+
+        var json = JsonSerializer.Serialize(document, _options);
+
+        var expectedJson = @"
+            {
+                ""$id"": ""1"",
+                ""$collectionId"": ""col1"",
+                ""$databaseId"": ""db1"",
+                ""$createdAt"": ""2020-10-15T06:38:00.000+00:00"",
+                ""$updatedAt"": ""2020-10-15T06:38:00.000+00:00"",
+                ""$permissions"": null,
+                ""Field1"": ""value1"",
+                ""Field2"": 42,
+                ""Field3"": true,
+                ""Field4"": ""2020-10-15T06:38:00.000+00:00"",
+                ""Field5"": [""item1"", ""item2""],
+                ""Field6"": { ""key1"": ""value1"", ""key2"": 2 },
+                ""FloatField"": null,
+                ""LongField"": null,
+                ""DoubleField"": null
+            }".ReplaceLineEndings("").Replace(" ", "");
+
+        Assert.Equal(JsonDocument.Parse(expectedJson).RootElement.ToString(), JsonDocument.Parse(json).RootElement.ToString());
+    }
 }


### PR DESCRIPTION
# Changes
<!-- Provide a summary of the changes you have made. -->
- Applied a fix serializing documents

## Issue
<!-- Enter the ticket number and link to the issue you are completing, if appropriate -->

## Categorise the PR
<!-- Select at least one category from below that best describes this PR and what it does -->
- [ ] `feature`
- [x] `bug`
- [ ] `docs`
- [ ] `security`
- [ ] `meta`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the document serialization process to handle null permissions by writing a null value, along with version increment to 1.0.2 and the addition of unit tests for validation.

### Why are these changes being made?

The previous configuration did not handle null permissions correctly during document serialization, potentially leading to serialization errors. By writing null in these cases, we ensure a robust and error-free serialization process. Unit tests have been added to verify that documents with null permissions serialize correctly, supporting both standard and generic document converters.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->