### PR TITLE
Fixed a bug with serializing anything using Nullable DateTimes

### DIFF
--- a/src/PinguApps.Appwrite.Shared/Constants.cs
+++ b/src/PinguApps.Appwrite.Shared/Constants.cs
@@ -1,5 +1,5 @@
 ﻿namespace PinguApps.Appwrite.Shared;
 public static class Constants
 {
-    public const string Version = "1.0.2";
+    public const string Version = "1.0.3";
 }

--- a/src/PinguApps.Appwrite.Shared/Converters/NullableDateTimeConverter.cs
+++ b/src/PinguApps.Appwrite.Shared/Converters/NullableDateTimeConverter.cs
@@ -29,5 +29,9 @@ public class NullableDateTimeConverter : JsonConverter<DateTime?>
         {
             _dateTimeConverter.Write(writer, value.Value, options);
         }
+        else
+        {
+            writer.WriteNullValue();
+        }
     }
 }

--- a/tests/PinguApps.Appwrite.Shared.Tests/Converters/NullableDateTimeConverterTests.cs
+++ b/tests/PinguApps.Appwrite.Shared.Tests/Converters/NullableDateTimeConverterTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using System.Text;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using PinguApps.Appwrite.Shared.Converters;
 
@@ -93,5 +94,24 @@ public class NullableDateTimeConverterTests
     {
         var json = JsonSerializer.Serialize(new NullableDateTimeObject(), _options);
         Assert.Equal("{\"x\":null}", json);
+    }
+
+    [Fact]
+    public void Write_WhenValueIsNull_WritesNullValue()
+    {
+        // Arrange
+        var converter = new NullableDateTimeConverter();
+        DateTime? nullDateTime = null;
+
+        using var stream = new MemoryStream();
+        using var writer = new Utf8JsonWriter(stream);
+
+        // Act
+        converter.Write(writer, nullDateTime, _options);
+        writer.Flush();
+
+        // Assert
+        var json = Encoding.UTF8.GetString(stream.ToArray());
+        Assert.Equal("null", json);
     }
 }


### PR DESCRIPTION
# Changes
<!-- Provide a summary of the changes you have made. -->
- Fixed a bug with serializing anything using Nullable DateTimes

## Issue
<!-- Enter the ticket number and link to the issue you are completing, if appropriate -->

## Categorise the PR
<!-- Select at least one category from below that best describes this PR and what it does -->
- [ ] `feature`
- [x] `bug`
- [ ] `docs`
- [ ] `security`
- [ ] `meta`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix the bug in `NullableDateTimeConverter` by correctly handling null `DateTime` values during JSON serialization, and update the version number to 1.0.3.

### Why are these changes being made?

Previously, when a null `DateTime?` was encountered, serialization did not properly account for this, causing potential errors or invalid JSON output. The code now explicitly writes a null value for such cases, ensuring accurate serialization. The update in version reflects the bug fix and promotes clarity in version tracking. Adding a test validates this correction.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->