### PR TITLE
Fixed reading json for documents

### DIFF
--- a/src/PinguApps.Appwrite.Shared/Constants.cs
+++ b/src/PinguApps.Appwrite.Shared/Constants.cs
@@ -1,5 +1,5 @@
 ﻿namespace PinguApps.Appwrite.Shared;
 public static class Constants
 {
-    public const string Version = "1.0.3";
+    public const string Version = "1.0.4";
 }

--- a/src/PinguApps.Appwrite.Shared/Converters/DocumentGenericConverter.cs
+++ b/src/PinguApps.Appwrite.Shared/Converters/DocumentGenericConverter.cs
@@ -43,7 +43,7 @@ public class DocumentGenericConverter<TData> : JsonConverter<Document<TData>>
 
     private DocumentFields ReadDocumentFields(ref Utf8JsonReader reader, JsonSerializerOptions options)
     {
-        var dateTimeConverter = new MultiFormatDateTimeConverter();
+        var dateTimeConverter = new NullableDateTimeConverter();
         var permissionListConverter = new PermissionListConverter();
         var fields = new DocumentFields();
 
@@ -64,7 +64,7 @@ public class DocumentGenericConverter<TData> : JsonConverter<Document<TData>>
     }
 
     private static void ProcessProperty(ref Utf8JsonReader reader, string propertyName, DocumentFields fields,
-        MultiFormatDateTimeConverter dateTimeConverter, PermissionListConverter permissionListConverter, JsonSerializerOptions options)
+        NullableDateTimeConverter dateTimeConverter, PermissionListConverter permissionListConverter, JsonSerializerOptions options)
     {
         switch (propertyName)
         {
@@ -223,7 +223,7 @@ public class DocumentGenericConverter<TData> : JsonConverter<Document<TData>>
 
     internal void WriteValue(Utf8JsonWriter writer, JsonElement element, JsonSerializerOptions options)
     {
-        var dateTimeConverter = new MultiFormatDateTimeConverter();
+        var dateTimeConverter = new NullableDateTimeConverter();
 
         switch (element.ValueKind)
         {

--- a/src/PinguApps.Appwrite.Shared/Converters/NullableDateTimeConverter.cs
+++ b/src/PinguApps.Appwrite.Shared/Converters/NullableDateTimeConverter.cs
@@ -9,6 +9,11 @@ public class NullableDateTimeConverter : JsonConverter<DateTime?>
 
     public override DateTime? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
+        if (reader.TokenType == JsonTokenType.Null)
+        {
+            return null;
+        }
+
         if (reader.TokenType == JsonTokenType.String)
         {
             var stringValue = reader.GetString();

--- a/src/PinguApps.Appwrite.Shared/Converters/PermissionListConverter.cs
+++ b/src/PinguApps.Appwrite.Shared/Converters/PermissionListConverter.cs
@@ -11,6 +11,11 @@ public class PermissionListConverter : JsonConverter<List<Permission>>
 
     public override List<Permission>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
+        if (reader.TokenType == JsonTokenType.Null)
+        {
+            return null;
+        }
+
         if (reader.TokenType is not JsonTokenType.StartArray)
         {
             throw new JsonException("Expected start of array");

--- a/tests/PinguApps.Appwrite.Shared.Tests/Converters/NullableDateTimeConverterTests.cs
+++ b/tests/PinguApps.Appwrite.Shared.Tests/Converters/NullableDateTimeConverterTests.cs
@@ -114,4 +114,20 @@ public class NullableDateTimeConverterTests
         var json = Encoding.UTF8.GetString(stream.ToArray());
         Assert.Equal("null", json);
     }
+
+    [Fact]
+    public void Read_DirectNullToken_ReturnsNull()
+    {
+        // Arrange
+        var converter = new NullableDateTimeConverter();
+        var json = "null";
+        var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json));
+        reader.Read(); // Advance to first token
+
+        // Act
+        var result = converter.Read(ref reader, typeof(DateTime?), _options);
+
+        // Assert
+        Assert.Null(result);
+    }
 }

--- a/tests/PinguApps.Appwrite.Shared.Tests/Converters/PermissionListConverterTests.cs
+++ b/tests/PinguApps.Appwrite.Shared.Tests/Converters/PermissionListConverterTests.cs
@@ -157,4 +157,20 @@ public class PermissionListConverterTests
         var expectedJson = "[\"read(\\\"any\\\")\",\"write(\\\"user:123/verified\\\")\",\"create(\\\"team:456/admin\\\")\"]";
         Assert.Equal(expectedJson, json);
     }
+
+    [Fact]
+    public void Read_DirectNullToken_ReturnsNull()
+    {
+        // Arrange
+        var converter = new PermissionListConverter();
+        var json = "null";
+        var reader = new Utf8JsonReader(System.Text.Encoding.UTF8.GetBytes(json));
+        reader.Read(); // Advance to first token
+
+        // Act
+        var result = converter.Read(ref reader, typeof(List<Permission>), _options);
+
+        // Assert
+        Assert.Null(result);
+    }
 }


### PR DESCRIPTION
# Changes
<!-- Provide a summary of the changes you have made. -->
- Fixed reading json for documents

## Issue
<!-- Enter the ticket number and link to the issue you are completing, if appropriate -->

## Categorise the PR
<!-- Select at least one category from below that best describes this PR and what it does -->
- [ ] `feature`
- [x] `bug`
- [ ] `docs`
- [ ] `security`
- [ ] `meta`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Change the `MultiFormatDateTimeConverter` to `NullableDateTimeConverter` in the `DocumentGenericConverter`, and handle null values in `NullableDateTimeConverter` and `PermissionListConverter`, including added tests for handling null values.

### Why are these changes being made?

The changes ensure that the converters can gracefully handle JSON null values, enhancing the robustness and reliability of JSON parsing. Switching to `NullableDateTimeConverter` resolves issues with nullable DateTime values, improving the codebase's consistency and correctness when dealing with optional dates.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->