### PR TITLE
Added additional method to create document but return another type

### DIFF
--- a/src/PinguApps.Appwrite.Client/Clients/ClientDatabasesClient.cs
+++ b/src/PinguApps.Appwrite.Client/Clients/ClientDatabasesClient.cs
@@ -89,6 +89,25 @@ public class ClientDatabasesClient : SessionAwareClientBase, IClientDatabasesCli
     }
 
     /// <inheritdoc/>
+    public async Task<AppwriteResult<Document<TResponse>>> CreateDocument<TData, TResponse>(CreateDocumentRequest<TData> request)
+        where TData : class, new()
+        where TResponse : class, new()
+    {
+        try
+        {
+            request.Validate(true);
+
+            var result = await _databasesApi.CreateDocument<TData, TResponse>(GetCurrentSession(), request.DatabaseId, request.CollectionId, request);
+
+            return result.GetApiResponse();
+        }
+        catch (Exception e)
+        {
+            return e.GetExceptionResponse<Document<TResponse>>();
+        }
+    }
+
+    /// <inheritdoc/>
     public async Task<AppwriteResult> DeleteDocument(DeleteDocumentRequest request)
     {
         try

--- a/src/PinguApps.Appwrite.Client/Clients/IClientDatabasesClient.cs
+++ b/src/PinguApps.Appwrite.Client/Clients/IClientDatabasesClient.cs
@@ -49,6 +49,18 @@ public interface IClientDatabasesClient
     Task<AppwriteResult<Document<TData>>> CreateDocument<TData>(CreateDocumentRequest<TData> request) where TData : class, new();
 
     /// <summary>
+    /// Create a new Document. Before using this route, you should create a new collection resource using either a <see href="https://appwrite.io/docs/server/databases#databasesCreateCollection">server integration</see> API or directly from your database console.
+    /// <para><see href="https://appwrite.io/docs/references/cloud/client-rest/databases#createDocument">Appwrite Docs</see></para>
+    /// </summary>
+    /// <typeparam name="TData">The type of the data</typeparam>
+    /// <typeparam name="TResponse">The type of the response</typeparam>
+    /// <param name="request">The request content</param>
+    /// <returns>The document</returns>
+    Task<AppwriteResult<Document<TResponse>>> CreateDocument<TData, TResponse>(CreateDocumentRequest<TData> request)
+        where TData : class, new()
+        where TResponse : class, new();
+
+    /// <summary>
     /// Delete a document by its unique ID.
     /// <para><see href="https://appwrite.io/docs/references/cloud/client-rest/databases#deleteDocument">Appwrite Docs</see></para>
     /// </summary>

--- a/src/PinguApps.Appwrite.Client/Internals/IDatabasesApi.cs
+++ b/src/PinguApps.Appwrite.Client/Internals/IDatabasesApi.cs
@@ -22,6 +22,9 @@ internal interface IDatabasesApi : IBaseApi
     [Post("/databases/{databaseId}/collections/{collectionId}/documents")]
     Task<IApiResponse<Document<TData>>> CreateDocument<TData>([Header("x-appwrite-session")] string? session, string databaseId, string collectionId, CreateDocumentRequest<TData> request) where TData : class, new();
 
+    [Post("/databases/{databaseId}/collections/{collectionId}/documents")]
+    Task<IApiResponse<Document<TResponse>>> CreateDocument<TData, TResponse>([Header("x-appwrite-session")] string? session, string databaseId, string collectionId, CreateDocumentRequest<TData> request) where TData : class, new() where TResponse : class, new();
+
     [Delete("/databases/{databaseId}/collections/{collectionId}/documents/{documentId}")]
     Task<IApiResponse> DeleteDocument([Header("x-appwrite-session")] string? session, string databaseId, string collectionId, string documentId);
 

--- a/src/PinguApps.Appwrite.Server/Clients/IServerDatabasesClient.cs
+++ b/src/PinguApps.Appwrite.Server/Clients/IServerDatabasesClient.cs
@@ -316,6 +316,18 @@ public interface IServerDatabasesClient
     Task<AppwriteResult<Document<TData>>> CreateDocument<TData>(CreateDocumentRequest<TData> request) where TData : class, new();
 
     /// <summary>
+    /// Create a new Document. Before using this route, you should create a new collection resource using either <see cref="CreateCollection(CreateCollectionRequest)"/> or directly from your database console.
+    /// <para><see href="https://appwrite.io/docs/references/cloud/server-rest/databases#createDocument">Appwrite Docs</see></para>
+    /// </summary>
+    /// <typeparam name="TData">The data type for your data</typeparam>
+    /// <typeparam name="TResponse">The data type for your response</typeparam>
+    /// <param name="request">The request content</param>
+    /// <returns>The document</returns>
+    Task<AppwriteResult<Document<TResponse>>> CreateDocument<TData, TResponse>(CreateDocumentRequest<TData> request)
+        where TData : class, new()
+        where TResponse : class, new();
+
+    /// <summary>
     /// Delete a document by its unique ID.
     /// <para><see href="https://appwrite.io/docs/references/cloud/server-rest/databases#deleteDocument">Appwrite Docs</see></para>
     /// </summary>

--- a/src/PinguApps.Appwrite.Server/Clients/ServerDatabasesClient.cs
+++ b/src/PinguApps.Appwrite.Server/Clients/ServerDatabasesClient.cs
@@ -652,6 +652,25 @@ public class ServerDatabasesClient : IServerDatabasesClient
     }
 
     /// <inheritdoc/>
+    public async Task<AppwriteResult<Document<TResponse>>> CreateDocument<TData, TResponse>(CreateDocumentRequest<TData> request)
+        where TData : class, new()
+        where TResponse : class, new()
+    {
+        try
+        {
+            request.Validate(true);
+
+            var result = await _databasesApi.CreateDocument<TData, TResponse>(request.DatabaseId, request.CollectionId, request);
+
+            return result.GetApiResponse();
+        }
+        catch (Exception e)
+        {
+            return e.GetExceptionResponse<Document<TResponse>>();
+        }
+    }
+
+    /// <inheritdoc/>
     public async Task<AppwriteResult> DeleteDocument(DeleteDocumentRequest request)
     {
         try

--- a/src/PinguApps.Appwrite.Server/Internals/IDatabasesApi.cs
+++ b/src/PinguApps.Appwrite.Server/Internals/IDatabasesApi.cs
@@ -131,6 +131,9 @@ internal interface IDatabasesApi : IBaseApi
     [Post("/databases/{databaseId}/collections/{collectionId}/documents")]
     Task<IApiResponse<Document<TData>>> CreateDocument<TData>(string databaseId, string collectionId, CreateDocumentRequest<TData> request) where TData : class, new();
 
+    [Post("/databases/{databaseId}/collections/{collectionId}/documents")]
+    Task<IApiResponse<Document<TResponse>>> CreateDocument<TData, TResponse>(string databaseId, string collectionId, CreateDocumentRequest<TData> request) where TData : class, new() where TResponse : class, new();
+
     [Delete("/databases/{databaseId}/collections/{collectionId}/documents/{documentId}")]
     Task<IApiResponse> DeleteDocument(string databaseId, string collectionId, string documentId);
 

--- a/src/PinguApps.Appwrite.Shared/Constants.cs
+++ b/src/PinguApps.Appwrite.Shared/Constants.cs
@@ -1,5 +1,5 @@
 ﻿namespace PinguApps.Appwrite.Shared;
 public static class Constants
 {
-    public const string Version = "1.1.2";
+    public const string Version = "1.1.3";
 }

--- a/tests/PinguApps.Appwrite.Client.Tests/Clients/Databases/DatabasesClientTests.CreateDocumentGenericGeneric.cs
+++ b/tests/PinguApps.Appwrite.Client.Tests/Clients/Databases/DatabasesClientTests.CreateDocumentGenericGeneric.cs
@@ -1,0 +1,125 @@
+﻿using System.Net;
+using PinguApps.Appwrite.Shared.Requests.Databases;
+using PinguApps.Appwrite.Shared.Tests;
+using PinguApps.Appwrite.Shared.Utils;
+using RichardSzalay.MockHttp;
+
+namespace PinguApps.Appwrite.Client.Tests.Clients.Databases;
+public partial class DatabasesClientTests
+{
+
+    [Fact]
+    public async Task CreateDocumentGenericGeneric_ShouldReturnSuccess_WhenApiCallSucceeds()
+    {
+        // Arrange
+        var request = new CreateDocumentRequest<TestData>()
+        {
+            DatabaseId = IdUtils.GenerateUniqueId(),
+            CollectionId = IdUtils.GenerateUniqueId(),
+            Data = new TestData()
+            {
+                Name = "Test",
+                Age = 25
+            }
+        };
+
+        _mockHttp.Expect(HttpMethod.Post, $"{TestConstants.Endpoint}/databases/{request.DatabaseId}/collections/{request.CollectionId}/documents")
+            .ExpectedHeaders()
+            .WithJsonContent(request, _jsonSerializerOptions)
+            .Respond(TestConstants.AppJson, TestConstants.DocumentGenericResponse);
+
+        // Act
+        var result = await _appwriteClient.Databases.CreateDocument<TestData, TestDataResponse>(request);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.Equal("Test", result.Result.AsT0.Data.Name);
+        Assert.Equal(25, result.Result.AsT0.Data.Age);
+    }
+
+    [Fact]
+    public async Task CreateDocumentGenericGeneric_ShouldIncludeSessionHeaders_WhenProvided()
+    {
+        // Arrange
+        var request = new CreateDocumentRequest<TestData>()
+        {
+            DatabaseId = IdUtils.GenerateUniqueId(),
+            CollectionId = IdUtils.GenerateUniqueId(),
+            Data = new TestData()
+            {
+                Name = "Test",
+                Age = 25
+            }
+        };
+
+        _mockHttp.Expect(HttpMethod.Post, $"{TestConstants.Endpoint}/databases/{request.DatabaseId}/collections/{request.CollectionId}/documents")
+            .ExpectedHeaders()
+            .WithJsonContent(request, _jsonSerializerOptions)
+            .Respond(TestConstants.AppJson, TestConstants.DocumentResponse);
+
+        _appwriteClient.SetSession(TestConstants.Session);
+
+        // Act
+        var result = await _appwriteClient.Databases.CreateDocument<TestData, TestDataResponse>(request);
+
+        // Assert
+        _mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task CreateDocumentGenericGeneric_ShouldHandleException_WhenApiCallFails()
+    {
+        // Arrange
+        var request = new CreateDocumentRequest<TestData>()
+        {
+            DatabaseId = IdUtils.GenerateUniqueId(),
+            CollectionId = IdUtils.GenerateUniqueId(),
+            Data = new TestData()
+            {
+                Name = "Test",
+                Age = 25
+            }
+        };
+
+        _mockHttp.Expect(HttpMethod.Post, $"{TestConstants.Endpoint}/databases/{request.DatabaseId}/collections/{request.CollectionId}/documents")
+            .ExpectedHeaders()
+            .WithJsonContent(request, _jsonSerializerOptions)
+            .Respond(HttpStatusCode.BadRequest, TestConstants.AppJson, TestConstants.AppwriteError);
+
+        // Act
+        var result = await _appwriteClient.Databases.CreateDocument<TestData, TestDataResponse>(request);
+
+        // Assert
+        Assert.True(result.IsError);
+        Assert.True(result.IsAppwriteError);
+    }
+
+    [Fact]
+    public async Task CreateDocumentGenericGeneric_ShouldReturnErrorResponse_WhenExceptionOccurs()
+    {
+        // Arrange
+        var request = new CreateDocumentRequest<TestData>()
+        {
+            DatabaseId = IdUtils.GenerateUniqueId(),
+            CollectionId = IdUtils.GenerateUniqueId(),
+            Data = new TestData()
+            {
+                Name = "Test",
+                Age = 25
+            }
+        };
+
+        _mockHttp.Expect(HttpMethod.Post, $"{TestConstants.Endpoint}/databases/{request.DatabaseId}/collections/{request.CollectionId}/documents")
+            .ExpectedHeaders()
+            .WithJsonContent(request, _jsonSerializerOptions)
+            .Throw(new HttpRequestException("An error occurred"));
+
+        // Act
+        var result = await _appwriteClient.Databases.CreateDocument<TestData, TestDataResponse>(request);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.True(result.IsInternalError);
+        Assert.Equal("An error occurred", result.Result.AsT2.Message);
+    }
+}

--- a/tests/PinguApps.Appwrite.Client.Tests/Clients/Databases/DatabasesClientTests.CreateDocumentGenericGeneric.cs
+++ b/tests/PinguApps.Appwrite.Client.Tests/Clients/Databases/DatabasesClientTests.CreateDocumentGenericGeneric.cs
@@ -7,7 +7,6 @@ using RichardSzalay.MockHttp;
 namespace PinguApps.Appwrite.Client.Tests.Clients.Databases;
 public partial class DatabasesClientTests
 {
-
     [Fact]
     public async Task CreateDocumentGenericGeneric_ShouldReturnSuccess_WhenApiCallSucceeds()
     {

--- a/tests/PinguApps.Appwrite.Client.Tests/Clients/Databases/DatabasesClientTests.cs
+++ b/tests/PinguApps.Appwrite.Client.Tests/Clients/Databases/DatabasesClientTests.cs
@@ -44,4 +44,8 @@ public partial class DatabasesClientTests
         [JsonPropertyName("age")]
         public int Age { get; set; } = 0;
     }
+    public class TestDataResponse : TestData
+    {
+
+    }
 }

--- a/tests/PinguApps.Appwrite.Client.Tests/Clients/Databases/DatabasesClientTests.cs
+++ b/tests/PinguApps.Appwrite.Client.Tests/Clients/Databases/DatabasesClientTests.cs
@@ -46,6 +46,5 @@ public partial class DatabasesClientTests
     }
     public class TestDataResponse : TestData
     {
-
     }
 }

--- a/tests/PinguApps.Appwrite.Server.Tests/Clients/Databases/DatabasesClientTests.CreateDocumentGenericGeneric.cs
+++ b/tests/PinguApps.Appwrite.Server.Tests/Clients/Databases/DatabasesClientTests.CreateDocumentGenericGeneric.cs
@@ -1,0 +1,95 @@
+﻿using System.Net;
+using PinguApps.Appwrite.Shared.Requests.Databases;
+using PinguApps.Appwrite.Shared.Tests;
+using PinguApps.Appwrite.Shared.Utils;
+using RichardSzalay.MockHttp;
+
+namespace PinguApps.Appwrite.Server.Tests.Clients.Databases;
+public partial class DatabasesClientTests
+{
+    [Fact]
+    public async Task CreateDocumentGenericGeneric_ShouldReturnSuccess_WhenApiCallSucceeds()
+    {
+        // Arrange
+        var request = new CreateDocumentRequest<TestData>()
+        {
+            DatabaseId = IdUtils.GenerateUniqueId(),
+            CollectionId = IdUtils.GenerateUniqueId(),
+            Data = new TestData()
+            {
+                Name = "Test",
+                Age = 25
+            }
+        };
+
+        _mockHttp.Expect(HttpMethod.Post, $"{TestConstants.Endpoint}/databases/{request.DatabaseId}/collections/{request.CollectionId}/documents")
+            .ExpectedHeaders()
+            .WithJsonContent(request, _jsonSerializerOptions)
+            .Respond(TestConstants.AppJson, TestConstants.DocumentGenericResponse);
+
+        // Act
+        var result = await _appwriteClient.Databases.CreateDocument<TestData, TestDataResponse>(request);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.Equal("Test", result.Result.AsT0.Data.Name);
+        Assert.Equal(25, result.Result.AsT0.Data.Age);
+    }
+
+    [Fact]
+    public async Task CreateDocumentGenericGeneric_ShouldHandleException_WhenApiCallFails()
+    {
+        // Arrange
+        var request = new CreateDocumentRequest<TestData>()
+        {
+            DatabaseId = IdUtils.GenerateUniqueId(),
+            CollectionId = IdUtils.GenerateUniqueId(),
+            Data = new TestData()
+            {
+                Name = "Test",
+                Age = 25
+            }
+        };
+
+        _mockHttp.Expect(HttpMethod.Post, $"{TestConstants.Endpoint}/databases/{request.DatabaseId}/collections/{request.CollectionId}/documents")
+            .ExpectedHeaders()
+            .WithJsonContent(request, _jsonSerializerOptions)
+            .Respond(HttpStatusCode.BadRequest, TestConstants.AppJson, TestConstants.AppwriteError);
+
+        // Act
+        var result = await _appwriteClient.Databases.CreateDocument<TestData, TestDataResponse>(request);
+
+        // Assert
+        Assert.True(result.IsError);
+        Assert.True(result.IsAppwriteError);
+    }
+
+    [Fact]
+    public async Task CreateDocumentGenericGeneric_ShouldReturnErrorResponse_WhenExceptionOccurs()
+    {
+        // Arrange
+        var request = new CreateDocumentRequest<TestData>()
+        {
+            DatabaseId = IdUtils.GenerateUniqueId(),
+            CollectionId = IdUtils.GenerateUniqueId(),
+            Data = new TestData()
+            {
+                Name = "Test",
+                Age = 25
+            }
+        };
+
+        _mockHttp.Expect(HttpMethod.Post, $"{TestConstants.Endpoint}/databases/{request.DatabaseId}/collections/{request.CollectionId}/documents")
+            .ExpectedHeaders()
+            .WithJsonContent(request, _jsonSerializerOptions)
+            .Throw(new HttpRequestException("An error occurred"));
+
+        // Act
+        var result = await _appwriteClient.Databases.CreateDocument<TestData, TestDataResponse>(request);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.True(result.IsInternalError);
+        Assert.Equal("An error occurred", result.Result.AsT2.Message);
+    }
+}

--- a/tests/PinguApps.Appwrite.Server.Tests/Clients/Databases/DatabasesClientTests.cs
+++ b/tests/PinguApps.Appwrite.Server.Tests/Clients/Databases/DatabasesClientTests.cs
@@ -45,4 +45,8 @@ public partial class DatabasesClientTests
         [JsonPropertyName("age")]
         public int Age { get; set; } = 0;
     }
+
+    public class TestDataResponse : TestData
+    {
+    }
 }

--- a/tests/PinguApps.Appwrite.Shared.Tests/Requests/Databases/UpdateDocumentRequestBuilderTests.cs
+++ b/tests/PinguApps.Appwrite.Shared.Tests/Requests/Databases/UpdateDocumentRequestBuilderTests.cs
@@ -94,6 +94,7 @@ public class UpdateDocumentRequestBuilderTests
 
         // Assert
         Assert.Same(builder, result);
+        Assert.NotNull(request.Permissions);
         Assert.Contains(permission, request.Permissions);
         Assert.Single(request.Permissions);
     }
@@ -112,6 +113,7 @@ public class UpdateDocumentRequestBuilderTests
         var request = builder.Build();
 
         // Assert
+        Assert.NotNull(request.Permissions);
         Assert.Equal(2, request.Permissions.Count);
         Assert.Contains(permission1, request.Permissions);
         Assert.Contains(permission2, request.Permissions);


### PR DESCRIPTION
# Changes
<!-- Provide a summary of the changes you have made. -->
- Added additional method to create document but return another type

## Issue
<!-- Enter the ticket number and link to the issue you are completing, if appropriate -->

## Categorise the PR
<!-- Select at least one category from below that best describes this PR and what it does -->
- [x] `feature`
- [ ] `bug`
- [ ] `docs`
- [ ] `security`
- [ ] `meta`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a new asynchronous method to create a document and return a different type of response, `CreateDocument<TData, TResponse>`, in both client and server components, and update related interfaces and test cases accordingly.

### Why are these changes being made?

This enhancement allows flexibility in handling different data types for requests and responses during document creation, which is useful in scenarios where transformation or different data formats are required. The new generic method supports varied response types, meeting specific needs of different use cases, while maintaining consistency and ensuring reliability through comprehensive testing.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->