### PR TITLE
Enable permissions on Doc Creation to be nulled

### DIFF
--- a/src/PinguApps.Appwrite.Shared/Constants.cs
+++ b/src/PinguApps.Appwrite.Shared/Constants.cs
@@ -1,5 +1,5 @@
 ﻿namespace PinguApps.Appwrite.Shared;
 public static class Constants
 {
-    public const string Version = "1.2.0";
+    public const string Version = "1.2.1";
 }

--- a/src/PinguApps.Appwrite.Shared/Requests/Databases/CreateDocumentRequestBuilder.cs
+++ b/src/PinguApps.Appwrite.Shared/Requests/Databases/CreateDocumentRequestBuilder.cs
@@ -48,6 +48,10 @@ internal class CreateDocumentRequestBuilder : ICreateDocumentRequestBuilder
 
     public ICreateDocumentRequestBuilder AddPermission(Permission permission)
     {
+        if (_request.Permissions is null)
+        {
+            _request.Permissions = [];
+        }
         _request.Permissions.Add(permission);
         return this;
     }

--- a/src/PinguApps.Appwrite.Shared/Requests/Databases/CreateDocumentRequestGeneric.cs
+++ b/src/PinguApps.Appwrite.Shared/Requests/Databases/CreateDocumentRequestGeneric.cs
@@ -30,5 +30,5 @@ public class CreateDocumentRequest<TData> : DatabaseCollectionIdBaseRequest<Crea
     /// </summary>
     [JsonPropertyName("permissions")]
     [JsonConverter(typeof(PermissionListConverter))]
-    public List<Permission> Permissions { get; set; } = [];
+    public List<Permission>? Permissions { get; set; }
 }

--- a/src/PinguApps.Appwrite.Shared/Requests/Databases/Validators/CreateDocumentRequestValidator.cs
+++ b/src/PinguApps.Appwrite.Shared/Requests/Databases/Validators/CreateDocumentRequestValidator.cs
@@ -17,9 +17,5 @@ public class CreateDocumentRequestValidator<TData> : AbstractValidator<CreateDoc
         RuleFor(x => x.Data)
             .NotNull()
             .WithMessage("Data is required.");
-
-        RuleFor(x => x.Permissions)
-            .NotNull()
-            .WithMessage("Permissions cannot be null.");
     }
 }

--- a/tests/PinguApps.Appwrite.Shared.Tests/Requests/Databases/CreateDocumentRequestBuilderTests.cs
+++ b/tests/PinguApps.Appwrite.Shared.Tests/Requests/Databases/CreateDocumentRequestBuilderTests.cs
@@ -94,6 +94,7 @@ public class CreateDocumentRequestBuilderTests
 
         // Assert
         Assert.Same(builder, result);
+        Assert.NotNull(request.Permissions);
         Assert.Contains(permission, request.Permissions);
         Assert.Single(request.Permissions);
     }
@@ -112,6 +113,7 @@ public class CreateDocumentRequestBuilderTests
         var request = builder.Build();
 
         // Assert
+        Assert.NotNull(request.Permissions);
         Assert.Equal(2, request.Permissions.Count);
         Assert.Contains(permission1, request.Permissions);
         Assert.Contains(permission2, request.Permissions);

--- a/tests/PinguApps.Appwrite.Shared.Tests/Requests/Databases/CreateDocumentRequestGenericTests.cs
+++ b/tests/PinguApps.Appwrite.Shared.Tests/Requests/Databases/CreateDocumentRequestGenericTests.cs
@@ -30,8 +30,7 @@ public class CreateDocumentRequestGenericTests : DatabaseCollectionIdBaseRequest
         // Assert
         Assert.NotEmpty(request.DocumentId);
         Assert.Null(request.Data);
-        Assert.NotNull(request.Permissions);
-        Assert.Empty(request.Permissions);
+        Assert.Null(request.Permissions);
     }
 
     [Fact]
@@ -129,14 +128,6 @@ public class CreateDocumentRequestGenericTests : DatabaseCollectionIdBaseRequest
             CollectionId = IdUtils.GenerateUniqueId(),
             DocumentId = IdUtils.GenerateUniqueId(),
             Data = null!
-        },
-        new()
-        {
-            DatabaseId = IdUtils.GenerateUniqueId(),
-            CollectionId = IdUtils.GenerateUniqueId(),
-            DocumentId = IdUtils.GenerateUniqueId(),
-            Data = new CreateDocumentTestData { Name = "Test", Age = 25 },
-            Permissions = null!
         }
     ];
 

--- a/tests/PinguApps.Appwrite.Shared.Tests/Requests/Databases/NonGenericCreateDocumentRequestTests.cs
+++ b/tests/PinguApps.Appwrite.Shared.Tests/Requests/Databases/NonGenericCreateDocumentRequestTests.cs
@@ -20,8 +20,7 @@ public class NonGenericCreateDocumentRequestTests : DatabaseCollectionIdBaseRequ
         // Assert
         Assert.NotEmpty(request.DocumentId);
         Assert.Null(request.Data);
-        Assert.NotNull(request.Permissions);
-        Assert.Empty(request.Permissions);
+        Assert.Null(request.Permissions);
     }
 
     [Theory]


### PR DESCRIPTION
# Changes
<!-- Provide a summary of the changes you have made. -->
- Enable permissions on Doc Creation to be nulled

## Issue
<!-- Enter the ticket number and link to the issue you are completing, if appropriate -->


## Categorise the PR
<!-- Select at least one category from below that best describes this PR and what it does -->
- [ ] `feature`
- [x] `bug`
- [ ] `docs`
- [ ] `security`
- [ ] `meta`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update code to allow document creation permissions to be nullable, modify validation rules accordingly, and update test cases to reflect the new behavior.

### Why are these changes being made?

These changes address the need to optionally define document permissions, improving the flexibility of the document creation process by allowing the exclusion of permissions when not required. This approach simplifies handling default or missing permissions scenarios, enhancing compatibility with various application use cases while maintaining robust testing to ensure consistency and reliability.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->