### PR TITLE
Removed setting headers as it appears this is incompatible with wasm

### DIFF
--- a/src/PinguApps.Appwrite.Realtime/RealtimeClient.cs
+++ b/src/PinguApps.Appwrite.Realtime/RealtimeClient.cs
@@ -88,19 +88,7 @@ internal class RealtimeClient : IAsyncDisposable, IRealtimeClient
     {
         var url = BuildWebSocketUrl();
 
-        var factory = new Func<ClientWebSocket>(() =>
-        {
-            var client = new ClientWebSocket();
-            client.Options.SetRequestHeader("x-sdk-name", ".NET");
-            client.Options.SetRequestHeader("x-sdk-platform", "realtime");
-            client.Options.SetRequestHeader("x-sdk-language", "dotnet");
-            client.Options.SetRequestHeader("x-sdk-version", Constants.Version);
-            client.Options.SetRequestHeader("X-Appwrite-Response-Format", "1.6.0");
-            client.Options.SetRequestHeader("X-Appwrite-Project", _config.ProjectId);
-            client.Options.SetRequestHeader("X-Appwrite-Session", _session);
-
-            return client;
-        });
+        var factory = new Func<ClientWebSocket>(() => new());
 
         _client = new WebsocketClient(url, factory)
         {


### PR DESCRIPTION
# Changes
<!-- Provide a summary of the changes you have made. -->
- Removed setting headers as it appears this is incompatible with wasm

## Issue
<!-- Enter the ticket number and link to the issue you are completing, if appropriate -->

## Categorise the PR
<!-- Select at least one category from below that best describes this PR and what it does -->
- [x] `feature`
- [ ] `bug`
- [ ] `docs`
- [ ] `security`
- [ ] `meta`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made? 

Remove the setting of headers in the WebSocket client factory function due to incompatibility with WebAssembly (Wasm).

### Why are these changes being made? 

The headers were removed because WebAssembly (Wasm) environments have limitations with setting WebSocket headers, thus causing compatibility issues. This change addresses these incompatibilities, ensuring that the `RealtimeClient` can function properly within Wasm contexts.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->