### PR TITLE
Changed default values for Enabled to true for create db and collection

### DIFF
--- a/src/PinguApps.Appwrite.Shared/Requests/Databases/CreateCollectionRequest.cs
+++ b/src/PinguApps.Appwrite.Shared/Requests/Databases/CreateCollectionRequest.cs
@@ -40,5 +40,5 @@ public class CreateCollectionRequest : DatabaseIdBaseRequest<CreateCollectionReq
     /// Is collection enabled? When set to 'disabled', users cannot access the collection but Server SDKs with and API key can still read and write to the collection. No data is lost when this is toggled.
     /// </summary>
     [JsonPropertyName("enabled")]
-    public bool Enabled { get; set; }
+    public bool Enabled { get; set; } = true;
 }

--- a/src/PinguApps.Appwrite.Shared/Requests/Databases/CreateDatabaseRequest.cs
+++ b/src/PinguApps.Appwrite.Shared/Requests/Databases/CreateDatabaseRequest.cs
@@ -25,5 +25,5 @@ public class CreateDatabaseRequest : BaseRequest<CreateDatabaseRequest, CreateDa
     /// Is the database enabled? When set to 'disabled', users cannot access the database but Server SDKs with an API key can still read and write to the database. No data is lost when this is toggled
     /// </summary>
     [JsonPropertyName("enabled")]
-    public bool Enabled { get; set; }
+    public bool Enabled { get; set; } = true;
 }

--- a/tests/PinguApps.Appwrite.Shared.Tests/Requests/Databases/CreateCollectionRequestTests.cs
+++ b/tests/PinguApps.Appwrite.Shared.Tests/Requests/Databases/CreateCollectionRequestTests.cs
@@ -23,7 +23,7 @@ public class CreateCollectionRequestTests : DatabaseIdBaseRequestTests<CreateCol
         Assert.Equal(string.Empty, request.Name);
         Assert.NotNull(request.Permissions);
         Assert.False(request.DocumentSecurity);
-        Assert.False(request.Enabled);
+        Assert.True(request.Enabled);
     }
 
     [Fact]

--- a/tests/PinguApps.Appwrite.Shared.Tests/Requests/Databases/CreateDatabaseRequestTests.cs
+++ b/tests/PinguApps.Appwrite.Shared.Tests/Requests/Databases/CreateDatabaseRequestTests.cs
@@ -14,7 +14,7 @@ public class CreateDatabaseRequestTests
         // Assert
         Assert.NotEmpty(request.DatabaseId);
         Assert.Equal(string.Empty, request.Name);
-        Assert.False(request.Enabled);
+        Assert.True(request.Enabled);
     }
 
     [Fact]


### PR DESCRIPTION
# Changes
<!-- Provide a summary of the changes you have made. -->
- Swapped default value for Enabled to true for create database and create collection requests
- Updated tests

## Issue
<!-- Enter the ticket number and link to the issue you are completing, if appropriate -->
Fixes #666 

## Categorise the PR
<!-- Select at least one category from below that best describes this PR and what it does -->
- [ ] `feature`
- [x] `bug`
- [ ] `docs`
- [ ] `security`
- [ ] `meta`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Set the default value of the `Enabled` property to `true` for both `CreateCollectionRequest` and `CreateDatabaseRequest` classes, along with updating the corresponding tests.

### Why are these changes being made?

These changes ensure that databases and collections are enabled by default upon creation, which aligns with common use cases where immediate accessibility is desired after creation. This change simplifies the process for users and reduces potential configuration steps, while the tests are updated to verify this new default behavior.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->