### PR TITLE
Prevents server SDK using cookies again

### DIFF
--- a/src/PinguApps.Appwrite.Server/PinguApps.Appwrite.Server.csproj
+++ b/src/PinguApps.Appwrite.Server/PinguApps.Appwrite.Server.csproj
@@ -50,9 +50,9 @@
 
   <Target DependsOnTargets="ResolveReferences" Name="CopyProjectReferencesToPackage">
     <ItemGroup>
-      <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
-      <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->Replace('.dll', '.xml'))" />
-      <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->Replace('.dll', '.pdb'))" />
+      <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
+      <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')-&gt;Replace('.dll', '.xml'))" />
+      <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')-&gt;Replace('.dll', '.pdb'))" />
     </ItemGroup>
   </Target>
 

--- a/src/PinguApps.Appwrite.Server/ServiceCollectionExtensions.cs
+++ b/src/PinguApps.Appwrite.Server/ServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
-// If you're using .NET Core 2.1 or later, add this:
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text.Json;

--- a/src/PinguApps.Appwrite.Server/ServiceCollectionExtensions.cs
+++ b/src/PinguApps.Appwrite.Server/ServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
+// If you're using .NET Core 2.1 or later, add this:
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -143,6 +145,15 @@ public static class ServiceCollectionExtensions
         if (messageHandler is HttpClientHandler clientHandler)
         {
             clientHandler.UseCookies = false;
+        }
+        else if (messageHandler.GetType().FullName == "System.Net.Http.SocketsHttpHandler")
+        {
+            // Use reflection to set the UseCookies property
+            PropertyInfo property = messageHandler.GetType().GetProperty("UseCookies");
+            if (property is not null)
+            {
+                property.SetValue(messageHandler, false);
+            }
         }
     }
 

--- a/src/PinguApps.Appwrite.Shared/Constants.cs
+++ b/src/PinguApps.Appwrite.Shared/Constants.cs
@@ -1,5 +1,5 @@
 ﻿namespace PinguApps.Appwrite.Shared;
 public static class Constants
 {
-    public const string Version = "2.0.6";
+    public const string Version = "2.1.0";
 }


### PR DESCRIPTION
# Changes
<!-- Provide a summary of the changes you have made. -->
- Prevents server SDK using cookies again

## Issue
<!-- Enter the ticket number and link to the issue you are completing, if appropriate -->

## Categorise the PR
<!-- Select at least one category from below that best describes this PR and what it does -->
- [ ] `feature`
- [x] `bug`
- [ ] `docs`
- [ ] `security`
- [ ] `meta`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the `ConfigurePrimaryHttpMessageHandler` function to prevent the server SDK from using cookies by utilizing reflection for .NET Core versions that use `SocketsHttpHandler`, and update the version number in `Constants.cs` from "2.0.6" to "2.1.0".

### Why are these changes being made?

This change addresses the need to disable cookie usage in the HttpMessageHandler to improve security and consistency across implementations, especially when using `SocketsHttpHandler` in .NET Core versions. The version number increase reflects this significant functionality update. Using reflection here effectively handles the non-public usage of the `UseCookies` property, ensuring comprehensive cookie management.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->