### PR TITLE
Enabled ability for users to specify customer headers - for example x-forwarded-for

### DIFF
--- a/src/PinguApps.Appwrite.Client/Handlers/HeaderHandler.cs
+++ b/src/PinguApps.Appwrite.Client/Handlers/HeaderHandler.cs
@@ -27,6 +27,11 @@ internal class HeaderHandler : DelegatingHandler
             request.Headers.UserAgent.Clear();
         }
 
+        foreach (var header in AppwriteRequestContext.CurrentHeaders)
+        {
+            request.Headers.TryAddWithoutValidation(header.Key, header.Value);
+        }
+
         return base.SendAsync(request, cancellationToken);
     }
 }

--- a/src/PinguApps.Appwrite.Playground/App.cs
+++ b/src/PinguApps.Appwrite.Playground/App.cs
@@ -1,7 +1,6 @@
-﻿using System.Text.Json.Serialization;
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using PinguApps.Appwrite.Realtime;
-using PinguApps.Appwrite.Shared.Responses;
+using PinguApps.Appwrite.Shared;
 
 namespace PinguApps.Appwrite.Playground;
 internal class App
@@ -19,24 +18,22 @@ internal class App
         _session = config.GetValue<string>("Session");
     }
 
-    public record Table1
-    {
-        [JsonPropertyName("test")] public string? Test { get; init; }
-        [JsonPropertyName("boolAttribute")] public bool BoolAttribute { get; init; }
-    }
-
     public async Task Run(string[] args)
     {
-        using (_realtimeClient.Subscribe<Document<Table1>>("documents", x =>
+        Task.Run(async () =>
         {
-            Console.WriteLine(x.Payload);
-        }))
-        {
-            await Task.Delay(5000);
+            using (var _ = new AppwriteHeaderScope("X-Forwarded-For", "1.2.3.4"))
+            {
+                var result = await _server.Account.CreateAnonymousSession();
 
-            _realtimeClient.SetSession(_session);
+                Console.WriteLine(result.Result);
+            }
+        });
 
-            Console.ReadKey();
-        }
+        var result2 = await _server.Account.CreateAnonymousSession();
+
+        Console.WriteLine(result2.Result);
+
+        Console.ReadKey();
     }
 }

--- a/src/PinguApps.Appwrite.Server/Handlers/HeaderHandler.cs
+++ b/src/PinguApps.Appwrite.Server/Handlers/HeaderHandler.cs
@@ -34,6 +34,11 @@ internal class HeaderHandler : DelegatingHandler
             request.Headers.UserAgent.Clear();
         }
 
+        foreach (var header in AppwriteRequestContext.CurrentHeaders)
+        {
+            request.Headers.TryAddWithoutValidation(header.Key, header.Value);
+        }
+
         return base.SendAsync(request, cancellationToken);
     }
 }

--- a/src/PinguApps.Appwrite.Shared/AppwriteHeaderScope.cs
+++ b/src/PinguApps.Appwrite.Shared/AppwriteHeaderScope.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace PinguApps.Appwrite.Shared;
+
+public class AppwriteHeaderScope : IDisposable
+{
+    private readonly Dictionary<string, (bool hadValue, string oldValue)> _originalState = [];
+
+    /// <summary>
+    /// Creates a new scope with a single header.
+    /// </summary>
+    /// <param name="key">The header name</param>
+    /// <param name="value">The header value</param>
+    public AppwriteHeaderScope(string key, string value)
+    {
+        StoreOriginalValue(key);
+        AppwriteRequestContext.AddHeader(key, value);
+    }
+
+    /// <summary>
+    /// Creates a new scope with multiple headers.
+    /// </summary>
+    /// <param name="headers">Dictionary of headers to add</param>
+    public AppwriteHeaderScope(IDictionary<string, string> headers)
+    {
+        foreach (var header in headers)
+        {
+            StoreOriginalValue(header.Key);
+        }
+
+        AppwriteRequestContext.AddHeaders(headers);
+    }
+
+    private void StoreOriginalValue(string key)
+    {
+        var hadValue = AppwriteRequestContext.CurrentHeaders.TryGetValue(key, out var oldValue);
+        _originalState[key] = (hadValue, oldValue);
+    }
+
+    /// <summary>
+    /// Restores the original header values from before this scope was created.
+    /// </summary>
+    public void Dispose()
+    {
+        foreach (var entry in _originalState)
+        {
+            var key = entry.Key;
+            var (hadValue, oldValue) = entry.Value;
+
+            if (hadValue)
+                AppwriteRequestContext.AddHeader(key, oldValue);
+            else
+                AppwriteRequestContext.CurrentHeaders.Remove(key);
+        }
+    }
+}

--- a/src/PinguApps.Appwrite.Shared/AppwriteRequestContext.cs
+++ b/src/PinguApps.Appwrite.Shared/AppwriteRequestContext.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+
+namespace PinguApps.Appwrite.Shared;
+
+public static class AppwriteRequestContext
+{
+    private static readonly AsyncLocal<Dictionary<string, string>> _headers = new();
+
+    /// <summary>
+    /// Gets the current request headers dictionary.
+    /// </summary>
+    public static Dictionary<string, string> CurrentHeaders
+    {
+        get => _headers.Value ??= [];
+    }
+
+    /// <summary>
+    /// Adds or updates a single header in the current context.
+    /// </summary>
+    public static void AddHeader(string key, string value)
+    {
+        CurrentHeaders[key] = value;
+    }
+
+    /// <summary>
+    /// Adds or updates multiple headers in the current context.
+    /// </summary>
+    public static void AddHeaders(IDictionary<string, string> headers)
+    {
+        foreach (var header in headers)
+        {
+            CurrentHeaders[header.Key] = header.Value;
+        }
+    }
+
+    /// <summary>
+    /// Clears all headers from the current context.
+    /// </summary>
+    public static void ClearHeaders()
+    {
+        _headers.Value = [];
+    }
+}

--- a/src/PinguApps.Appwrite.Shared/Constants.cs
+++ b/src/PinguApps.Appwrite.Shared/Constants.cs
@@ -1,5 +1,5 @@
 ﻿namespace PinguApps.Appwrite.Shared;
 public static class Constants
 {
-    public const string Version = "2.1.2";
+    public const string Version = "2.2.0";
 }


### PR DESCRIPTION
# Changes
<!-- Provide a summary of the changes you have made. -->
- Enabled ability for users to specify customer headers - for example x-forwarded-for

## Issue
<!-- Enter the ticket number and link to the issue you are completing, if appropriate -->

## Categorise the PR
<!-- Select at least one category from below that best describes this PR and what it does -->
- [x] `feature`
- [ ] `bug`
- [ ] `docs`
- [ ] `security`
- [ ] `meta`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Enable users to specify custom headers, such as `x-forwarded-for`, in requests by implementing `AppwriteRequestContext` and `AppwriteHeaderScope` for managing headers, and updating the header handlers in the client and server projects to incorporate these custom headers.

### Why are these changes being made?

These changes allow for greater flexibility in request handling by permitting users to add and manage custom headers dynamically, which is essential for supporting scenarios like forwarding header information in HTTP requests. This design provides an easy-to-use, encapsulated way to manage headers within a defined scope, allowing for easy integration into existing workflows.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->